### PR TITLE
Correct `dev-master` alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         },
         "commands": [
             "db create",


### PR DESCRIPTION
To allow for versions like 1.2.0 as well, the branch alias for `dev-master` needs to be changed from `1.0.x-dev` to `1.x-dev`.