### PR TITLE
Add option to skip tables when exporting a database

### DIFF
--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -19,3 +19,17 @@ Feature: Export a WordPress database
       wp_cli_test.sql
       """
     And the wp_cli_test.sql file should exist
+
+  Scenario: Exclude tables when exporting the dtabase
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql --exclude_tables=wp_users --porcelain`
+    Then the wp_cli_test.sql file should exist
+    And the wp_cli_test.sql file should not contain:
+      """
+      wp_users
+      """
+    And the wp_cli_test.sql file should contain:
+      """
+      wp_options
+      """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -335,7 +335,8 @@ class DB_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( isset( $assoc_args['exclude_tables'] ) ) {
+		$exclude_tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'exclude_tables' );
+		if ( isset( $exclude_tables ) ) {
 			$tables = explode( ',', trim( $assoc_args['exclude_tables'], ',' ) );
 			unset( $assoc_args['exclude_tables'] );
 			foreach ( $tables as $table ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -285,6 +285,18 @@ class DB_Command extends WP_CLI_Command {
 	 *     # Export all tables matching prefix
 	 *     $ wp db export --tables=$(wp db tables --all-tables-with-prefix --format=csv)
 	 *     Success: Exported to 'wordpress_dbase.sql'.
+	 * 
+	 *     # Skip certain tables from the exported database
+	 *     $ wp db export --skip-tables=wp_options,wp_users
+	 *     Success: Exported to 'wordpress_dbase.sql'.
+	 *
+	 *     # Skip all tables matching a wildcard from the exported database
+	 *     $ wp db export --skip-tables=$(wp db tables 'wp_user*' --format=csv)
+	 *     Success: Exported to 'wordpress_dbase.sql'.
+	 *
+	 *     # Skip all tables matching prefix from the exported database
+	 *     $ wp db export --skip-tables=$(wp db tables --all-tables-with-prefix --format=csv)
+	 *     Success: Exported to 'wordpress_dbase.sql'.
 	 *
 	 * @alias dump
 	 */
@@ -317,6 +329,16 @@ class DB_Command extends WP_CLI_Command {
 			foreach ( $tables as $table ) {
 				$command .= ' %s';
 				$command_esc_args[] = trim( $table );
+			}
+		}
+
+		if ( isset( $assoc_args['skip-tables'] ) ) {
+			$tables = explode( ',', trim( $assoc_args['skip-tables'], ',' ) );
+			unset( $assoc_args['skip-tables'] );
+			foreach ( $tables as $table ) {
+				$command .= ' --ignore-table';
+				$command .= ' %s';
+				$command_esc_args[] = trim( DB_NAME . '.' . $table );
 			}
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -264,6 +264,9 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--tables=<tables>]
 	 * : The comma separated list of specific tables to export. Excluding this parameter will export all tables in the database.
+	 * 
+	 * [--exclude_tables=<tables>]
+	 * : The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database.
 	 *
 	 * [--porcelain]
 	 * : Output filename for the exported database.
@@ -287,15 +290,15 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Exported to 'wordpress_dbase.sql'.
 	 * 
 	 *     # Skip certain tables from the exported database
-	 *     $ wp db export --skip-tables=wp_options,wp_users
+	 *     $ wp db export --exclude_tables=wp_options,wp_users
 	 *     Success: Exported to 'wordpress_dbase.sql'.
 	 *
 	 *     # Skip all tables matching a wildcard from the exported database
-	 *     $ wp db export --skip-tables=$(wp db tables 'wp_user*' --format=csv)
+	 *     $ wp db export --exclude_tables=$(wp db tables 'wp_user*' --format=csv)
 	 *     Success: Exported to 'wordpress_dbase.sql'.
 	 *
 	 *     # Skip all tables matching prefix from the exported database
-	 *     $ wp db export --skip-tables=$(wp db tables --all-tables-with-prefix --format=csv)
+	 *     $ wp db export --exclude_tables=$(wp db tables --all-tables-with-prefix --format=csv)
 	 *     Success: Exported to 'wordpress_dbase.sql'.
 	 *
 	 * @alias dump
@@ -332,9 +335,9 @@ class DB_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( isset( $assoc_args['skip-tables'] ) ) {
-			$tables = explode( ',', trim( $assoc_args['skip-tables'], ',' ) );
-			unset( $assoc_args['skip-tables'] );
+		if ( isset( $assoc_args['exclude_tables'] ) ) {
+			$tables = explode( ',', trim( $assoc_args['exclude_tables'], ',' ) );
+			unset( $assoc_args['exclude_tables'] );
 			foreach ( $tables as $table ) {
 				$command .= ' --ignore-table';
 				$command .= ' %s';


### PR DESCRIPTION
I am not exactly how to write tests for this as this will have to search for the table name inside the exported file.

Fixes #17 