### PR TITLE
Uppercase WP size_format() for pre 4.6 compat.

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -600,7 +600,7 @@ class DB_Command extends WP_CLI_Command {
 				// Add the table size to the list.
 				$rows[] = array(
 					'Name'  => $table_name,
-					'Size'  => size_format( $table_bytes ),
+					'Size'  => strtoupper( size_format( $table_bytes ) ),
 				);
 			}
 		} else {
@@ -615,7 +615,7 @@ class DB_Command extends WP_CLI_Command {
 			// Add the database size to the list.
 			$rows[] = array(
 				'Name'  => DB_NAME,
-				'Size'  => size_format( $db_bytes ),
+				'Size'  => strtoupper( size_format( $db_bytes ) ),
 				);
 		}
 


### PR DESCRIPTION
WP 4.6 changed the case of `size_format()` `kB` to upper ([changeset 37702](https://core.trac.wordpress.org/changeset/37702)), so `strtoupper()` it for compat.