### PR TITLE
Introduce orphan Subcommand

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -666,6 +666,190 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI::log( $wpdb->prefix );
 	}
 
+	/**
+	 * Display the IDs of all entries without existing reference object.
+	 *
+	 * For metadata, display all entries referencing an object that does not exist anymore. For comments and posts, display all entries referencing a post (parent) that does not exist anymore.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--type=<type>]
+	 * : Object type.
+	 * ---
+	 * default: post
+	 * options:
+	 *  - comment
+	 *  - commentmeta
+	 *  - post
+	 *  - postmeta
+	 *  - termmeta
+	 *  - usermeta
+	 * ---
+	 *
+	 * [--count]
+	 * : Print the number of found entries instead of the according IDs.
+	 *
+	 * [--delete]
+	 * : Delete all found entries.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp db orphan
+	 *     4
+	 *     8
+	 *     15
+	 *     16
+	 *     23
+	 *     42
+	 *
+	 *     $ wp db orphan --count
+	 *     Entries found: 8
+	 *
+	 *     $ wp db orphan --delete
+	 *     4
+	 *     8
+	 *     15
+	 *     16
+	 *     23
+	 *     42
+	 *     Entries deleted: 8
+	 *
+	 *     $ wp db orphan --type=usermeta
+	 *     1234
+	 */
+	public function orphan( array $args, array $assoc_args ) {
+
+		@WP_CLI::get_runner()->load_wordpress();
+
+		global $wpdb;
+
+		$valid_types = array(
+			'comment',
+			'commentmeta',
+			'post',
+			'postmeta',
+			'termmeta',
+			'usermeta',
+		);
+
+		if ( empty( $assoc_args['type'] ) ) {
+			$type = 'post';
+		} elseif ( in_array( $assoc_args['type'], $valid_types, true ) ) {
+			$type = $assoc_args['type'];
+		} else {
+			return;
+		}
+
+		$query_values = $this->get_orphan_query_values( $type );
+		if ( ! $query_values ) {
+			return;
+		}
+
+		$count = array_key_exists( 'count', $assoc_args );
+
+		$results = $wpdb->get_col( $wpdb->prepare(
+			'SELECT `%2$s` FROM `%1$s` WHERE `%3$s` != 0 AND `%3$s` NOT IN ( SELECT `%5$s` FROM `%4$s` )',
+			$query_values
+		) );
+		if ( ! $results ) {
+			if ( $count ) {
+				echo 'No entries found.' . PHP_EOL;
+			}
+
+			return;
+		}
+
+		if ( $count ) {
+			echo 'Entries found: ' . count( $results ) . PHP_EOL;
+		} else {
+			echo implode( PHP_EOL, $results ) . PHP_EOL;
+		}
+
+		if ( array_key_exists( 'delete', $assoc_args ) ) {
+			$deleted = (int) $wpdb->query( $wpdb->prepare(
+				'DELETE FROM `%1$s` WHERE `%2$s` IN ( ' . implode( ',', $results ) . ' )',
+				$query_values
+			) );
+			if ( $deleted ) {
+				WP_CLI::success( "Entries deleted: {$deleted}" );
+			} else {
+				WP_CLI::error( 'No entries deleted.' );
+			}
+		}
+	}
+
+	/**
+	 * Return the values needed by orphan() for the given type.
+	 *
+	 * @param string $type Object type.
+	 *
+	 * @return string[] Values needed by orphan_meta().
+	 */
+	private function get_orphan_query_values( $type ) {
+
+		@WP_CLI::get_runner()->load_wordpress();
+
+		global $wpdb;
+
+		switch ( $type ) {
+			case 'comment':
+				return array(
+					$wpdb->comments,
+					'comment_id',
+					'comment_post_ID',
+					$wpdb->posts,
+					'ID',
+				);
+
+			case 'commentmeta':
+				return array(
+					$wpdb->commentmeta,
+					'meta_id',
+					'comment_id',
+					$wpdb->comments,
+					'comment_ID',
+				);
+
+			case 'post':
+				return array(
+					$wpdb->postmeta,
+					'meta_id',
+					'post_id',
+					$wpdb->posts,
+					'ID',
+				);
+
+			case 'postmeta':
+				return array(
+					$wpdb->postmeta,
+					'meta_id',
+					'post_id',
+					$wpdb->posts,
+					'ID',
+				);
+
+			case 'termmeta':
+				return array(
+					$wpdb->termmeta,
+					'meta_id',
+					'term_id',
+					$wpdb->terms,
+					'term_id',
+				);
+
+			case 'usermeta':
+				return array(
+					$wpdb->usermeta,
+					'umeta_id',
+					'user_id',
+					$wpdb->users,
+					'ID',
+				);
+		}
+
+		return array();
+	}
+
 	private static function get_create_query() {
 
 		$create_query = sprintf( 'CREATE DATABASE `%s`', DB_NAME );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -812,9 +812,9 @@ class DB_Command extends WP_CLI_Command {
 
 			case 'post':
 				return array(
-					$wpdb->postmeta,
-					'meta_id',
-					'post_id',
+					$wpdb->posts,
+					'ID',
+					'post_parent',
 					$wpdb->posts,
 					'ID',
 				);

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -742,7 +742,7 @@ class DB_Command extends WP_CLI_Command {
 			return;
 		}
 
-		$count = array_key_exists( 'count', $assoc_args );
+		$count = Utils\get_flag_value( $assoc_args, 'count' );
 
 		$results = $wpdb->get_col( $wpdb->prepare(
 			'SELECT `%2$s` FROM `%1$s` WHERE `%3$s` != 0 AND `%3$s` NOT IN ( SELECT `%5$s` FROM `%4$s` )',
@@ -762,7 +762,7 @@ class DB_Command extends WP_CLI_Command {
 			echo implode( PHP_EOL, $results ) . PHP_EOL;
 		}
 
-		if ( array_key_exists( 'delete', $assoc_args ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'delete' ) ) {
 			$deleted = (int) $wpdb->query( $wpdb->prepare(
 				'DELETE FROM `%1$s` WHERE `%2$s` IN ( ' . implode( ',', $results ) . ' )',
 				$query_values

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -732,11 +732,8 @@ class DB_Command extends WP_CLI_Command {
 			'usermeta',
 		);
 
-		if ( empty( $assoc_args['type'] ) ) {
-			$type = 'post';
-		} elseif ( in_array( $assoc_args['type'], $valid_types, true ) ) {
-			$type = $assoc_args['type'];
-		} else {
+		$type = Utils\get_flag_value( $assoc_args, 'type', 'post' );
+		if ( ! in_array( $type, $valid_types, true ) ) {
 			return;
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -703,7 +703,7 @@ class DB_Command extends WP_CLI_Command {
 	 *     42
 	 *
 	 *     $ wp db orphan --count
-	 *     Entries found: 8
+	 *     Entries found: 6
 	 *
 	 *     $ wp db orphan --delete
 	 *     4
@@ -712,7 +712,7 @@ class DB_Command extends WP_CLI_Command {
 	 *     16
 	 *     23
 	 *     42
-	 *     Entries deleted: 8
+	 *     Entries deleted: 6
 	 *
 	 *     $ wp db orphan --type=usermeta
 	 *     1234


### PR DESCRIPTION
Hi there! 👋

----

### What's Included in This Pull Request

A new subcommand, `wp db orphan`, to list, count and/or delete orphaned entries (e.g., comments, posts or usermeta).

### Who Is This For?

WordPress offers dedicated APIs that are to be used for CRUD operations on the various core data structures. When deleting a comment via `wp_delete_comment( $some_id_here, true )`, WordPress takes care that all metadata for that comment gets automatically deleted as well. Great!

However, as we all know, people not always do what is right, and so it's not a rare situation that you have to face a database that is full of orphaned entries. Comment metadata of comments that no longer exist, comments for posts that no longer exists, or posts with parents that don't exist anymore.

With this new subcommand, you can easily spot orphans, and even delete them, if you want.

### How to Use It

By default, `wp db orphan` will only **list** the IDs, one at a line, and don't do anything to these orphans. Also, by default, the command will list orphaned **posts**, meaning posts with parents that no longer exist.

Via the `type` flag, you can define what kind of orphans you would like to target.  
Possible values are:

* `comment`: comments for non-existing posts;
* `commentmeta`: comment metadata for non-existing comments;
* `post`: posts with non-existing parents;
* `postmeta`: post metadata for non-existing posts;
* `termmeta`: term metadata for non-existing terms;
* `usermeta`: user metadata for non-existing users.

**Users** don't have any reference, so they are no option.

Also, **terms** are not an option, for at least two reasons:

* due to their ~bad~ _special_ table structure, both finding and deleting orphaned terms is more complex than anything above;
* it makes total sense to have terms that are not yet (or not anymore) in use (i.e., no post has that term assigned so far/anymore).

### Commenting on Comments

There's one thing about **comments**. The current code treats a comment as orphan if the referenced post does not exist any longer. However, comments also are (or can be) hierarchical, and thus (can) have a parent comment.

To be honest, I don't know exactly what is the _right_ definition of an orphaned comment. One that has a non-existing parent comment? One that has a non-existing post? One that has both?

If we only take one condition into account, implementing is as easy as updating three lines of code. If we were to use both, it would need a little more refactoring, although this wouldn't be a real problem.

----

So, what do you say? 😃

By the way, any combination of the three flags is possible, and makes sense.

Looking forward to feedback.

Cheers,
Thorsten