### PR TITLE
Revert #37 to remove `--stdout` for `wp db export`

### DIFF
--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -20,7 +20,7 @@ Feature: Export a WordPress database
       """
     And the wp_cli_test.sql file should exist
 
-  Scenario: Exclude tables when exporting the database
+  Scenario: Exclude tables when exporting the dtabase
     Given a WP install
 
     When I run `wp db export wp_cli_test.sql --exclude_tables=wp_users --porcelain`
@@ -32,25 +32,4 @@ Feature: Export a WordPress database
     And the wp_cli_test.sql file should contain:
       """
       wp_options
-      """
-
-  Scenario: Export database to STDOUT
-    Given a WP install
-
-    When I run `wp db export -`
-    Then STDOUT should contain:
-      """
-      -- MySQL dump
-      """
-
-    When I run `wp db export --stdout`
-    Then STDOUT should contain:
-      """
-      -- MySQL dump
-      """
-
-    When I try `wp db export - --stdout`
-    Then STDERR should be:
-      """
-      Error: The file name is not allowed when output mode is STDOUT.
       """

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -20,7 +20,7 @@ Feature: Export a WordPress database
       """
     And the wp_cli_test.sql file should exist
 
-  Scenario: Exclude tables when exporting the dtabase
+  Scenario: Exclude tables when exporting the database
     Given a WP install
 
     When I run `wp db export wp_cli_test.sql --exclude_tables=wp_users --porcelain`
@@ -32,4 +32,13 @@ Feature: Export a WordPress database
     And the wp_cli_test.sql file should contain:
       """
       wp_options
+      """
+
+  Scenario: Export database to STDOUT
+    Given a WP install
+
+    When I run `wp db export -`
+    Then STDOUT should contain:
+      """
+      -- MySQL dump
       """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -302,6 +302,15 @@ class DB_Command extends WP_CLI_Command {
 	 *     $ wp db export --exclude_tables=$(wp db tables --all-tables-with-prefix --format=csv)
 	 *     Success: Exported to 'wordpress_dbase-db72bb5.sql'.
 	 *
+	 *     # Export database to STDOUT.
+	 *     $ wp db export -
+	 *     -- MySQL dump 10.13  Distrib 5.7.19, for osx10.12 (x86_64)
+	 *     --
+	 *     -- Host: localhost    Database: wpdev
+	 *     -- ------------------------------------------------------
+	 *     -- Server version	5.7.19
+	 *     ...
+	 *
 	 * @alias dump
 	 */
 	public function export( $args, $assoc_args ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -269,9 +269,6 @@ class DB_Command extends WP_CLI_Command {
 	 * [--exclude_tables=<tables>]
 	 * : The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database.
 	 *
-	 * [--stdout]
-	 * : Output database to STDOUT.
-	 *
 	 * [--porcelain]
 	 * : Output filename for the exported database.
 	 *
@@ -305,15 +302,6 @@ class DB_Command extends WP_CLI_Command {
 	 *     $ wp db export --exclude_tables=$(wp db tables --all-tables-with-prefix --format=csv)
 	 *     Success: Exported to 'wordpress_dbase-db72bb5.sql'.
 	 *
-	 *     # Export database to STDOUT.
-	 *     $ wp db export --stdout
-	 *     -- MySQL dump 10.13  Distrib 5.7.19, for osx10.12 (x86_64)
-	 *     --
-	 *     -- Host: localhost    Database: wpdev
-	 *     -- ------------------------------------------------------
-	 *     -- Server version	5.7.19
-	 *     ...
-	 *
 	 * @alias dump
 	 */
 	public function export( $args, $assoc_args ) {
@@ -323,19 +311,7 @@ class DB_Command extends WP_CLI_Command {
 			$hash = substr( md5( mt_rand() ), 0, 7 );
 			$result_file = sprintf( '%s-%s-%s.sql', DB_NAME, date( 'Y-m-d' ), $hash );;
 		}
-
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'stdout' ) && ! empty( $args[0] ) ) {
-			WP_CLI::error( 'The file name is not allowed when output mode is STDOUT.' );
-		}
-
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'stdout' ) ) {
-			$stdout = true;
-		} elseif ( '-' === $result_file ) {
-			$stdout = true;
-		} else {
-			$stdout = false;
-		}
-
+		$stdout = ( '-' === $result_file );
 		$porcelain = \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' );
 
 		// Bail if both porcelain and STDOUT are set.
@@ -375,7 +351,6 @@ class DB_Command extends WP_CLI_Command {
 
 		// Remove parameters not needed for SQL run.
 		unset( $assoc_args['porcelain'] );
-		unset( $assoc_args['stdout'] );
 
 		self::run( $escaped_command, $assoc_args );
 


### PR DESCRIPTION
Related: #38 

#37 was reverted but we keep example and tests.