### PR TITLE
Cater for reserved word column/table names in db search.

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -901,3 +901,33 @@ Feature: Search through the database
       """
       Warning: Unrecognized percent color code '%x' for 'match_color'.
       """
+
+  Scenario: Search should cater for field/table names that use reserved words or unusual characters
+    Given a WP install
+    And a esc_sql_ident.sql file:
+      """
+      CREATE TABLE `TABLE` (`KEY` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT, `VALUES` TEXT, `back``tick` TEXT, `single'double"quote` TEXT, PRIMARY KEY (`KEY`) );
+      INSERT INTO `TABLE` (`VALUES`, `back``tick`, `single'double"quote`) VALUES ('v"v`v\'v\\v_v1', 'v"v`v\'v\\v_v1', 'v"v`v\'v\\v_v1' );
+      INSERT INTO `TABLE` (`VALUES`, `back``tick`, `single'double"quote`) VALUES ('v"v`v\'v\\v_v2', 'v"v`v\'v\\v_v2', 'v"v`v\'v\\v_v2' );
+      """
+
+    When I run `wp db query "SOURCE esc_sql_ident.sql;"`
+    Then STDERR should be empty
+
+    When I run `wp db search 'v_v' TABLE`
+    Then STDOUT should be:
+      """
+      TABLE:VALUES
+      1:v"v`v'v\v_v1
+      TABLE:VALUES
+      2:v"v`v'v\v_v2
+      TABLE:back`tick
+      1:v"v`v'v\v_v1
+      TABLE:back`tick
+      2:v"v`v'v\v_v2
+      TABLE:single'double"quote
+      1:v"v`v'v\v_v1
+      TABLE:single'double"quote
+      2:v"v`v'v\v_v2
+      """
+    And STDERR should be empty


### PR DESCRIPTION
Related PRs https://github.com/wp-cli/search-replace-command/pull/23 and https://github.com/wp-cli/search-replace-command/pull/4

Caters for reserved word column/table names in `db search`.

Also fixes double execution of `DESCRIBE TABLE` introduced by me in PR https://github.com/wp-cli/db-command/pull/29