### PR TITLE
db search: fix match in context in non-regex case.

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -908,3 +908,29 @@ Feature: Search through the database
       """
       Warning: Unrecognized percent color code '%x' for 'match_color'.
       """
+
+  Scenario: Search with matches within context
+    Given a WP install
+    And I run `wp option update matches_in_context '1234_XYXYX_2345678_XYXYX_2345678901_XYXYX_2345'`
+
+    When I run `wp db search XYXYX --before_context=10 --after_context=10 --stats`
+    Then STDOUT should contain:
+      """
+      Success: Found 3 matches
+      """
+    And STDOUT should contain:
+      """
+      :1234_XYXYX_2345678_X [...] X_2345678_XYXYX_234567890 [...] 345678901_XYXYX_2345
+      """
+    And STDERR should be empty
+
+    When I run `wp db search XYXYX --before_context=10 --after_context=10 --regex --stats`
+    Then STDOUT should contain:
+      """
+      Success: Found 3 matches
+      """
+    And STDOUT should contain:
+      """
+      :1234_XYXYX_2345678_X [...] X_2345678_XYXYX_234567890 [...] 345678901_XYXYX_2345
+      """
+    And STDERR should be empty


### PR DESCRIPTION
Issue https://github.com/wp-cli/db-command/issues/43

Removes context regex and always uses `PREG_OFFSET_CAPTURE` mode in `preg_match_all()` , to avoid missing matches in contexts.

Also no longer adds UTF-8 modifier `u` to regex ever, as not needed without context regex and was never needed anyway in `--regex` case.

Also rechecks encoding when non-UTF-8 for each value of `$col_val` as could get `ASCII` first time (unfortunately behat/gherkin can't handle non-UTF-8 chars in a feature file so will need a `phpunit` test to test this properly).