### PR TITLE
Change default regex delimiter to `chr(1)`

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -702,18 +702,22 @@ Feature: Search through the database
     Then STDOUT should be empty
 
     When I try `wp db search 'unfindable' --regex --regex-flags='abcd'`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Error: The regex '/unfindable/abcd' fails.
+      unfindable
       """
-    Then the return code should be 1
+    And STDERR should contain:
+      """
+      abcd
+      """
+    And the return code should be 1
 
     When I try `wp db search 'unfindable' --regex --regex-delimiter='1'`
     Then STDERR should be:
       """
       Error: The regex '1unfindable1' fails.
       """
-    Then the return code should be 1
+    And the return code should be 1
 
     When I run `wp db search '[0-9é]+?https:' --regex --regex-flags=u --before_context=0 --after_context=0`
     Then STDOUT should contain:
@@ -804,13 +808,8 @@ Feature: Search through the database
       st.com
       """
 
-    When I try `wp db search 'https://' --regex`
-    Then STDERR should contain:
-      """
-      Error: The regex '/https:///' fails.
-      """
-    And STDOUT should be empty
-    And the return code should be 1
+    When I run `wp db search 'https://' --regex`
+    Then the return code should be 0
 
   @require-wp-4.7
   Scenario: Search with output options

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -721,10 +721,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Pass PCRE modifiers to the regex search (e.g. 'i' for case-insensitivity). Note that 'u' (UTF-8 mode) will not be automatically added.
 	 *
 	 * [--regex-delimiter=<regex-delimiter>]
-	 * : The delimiter to use for the regex. It must be escaped if it appears in the search string.
-	 * ---
-	 * default: /
-	 * ---
+	 * : The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of `chr(1)`.
 	 *
 	 * [--table_column_once]
 	 * : Output the 'table:column' line once before all matching row lines in the table column rather than before each matching row.
@@ -820,9 +817,9 @@ class DB_Command extends WP_CLI_Command {
 
 		if ( ( $regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false ) ) ) {
 			$regex_flags = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
-			$regex_delimiter = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '/' );
+			$regex_delimiter = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', chr( 1 ) );
 			if ( '' === $regex_delimiter ) {
-				$regex_delimiter = '/';
+				$regex_delimiter = chr( 1 );
 			}
 		}
 


### PR DESCRIPTION
> The useful part is that it can return characters that you cannot easily type, so with something like chr(1), the chances of the delimiter being included in the pattern itself are practically null, whereas a / can easily be part of the actual pattern.

https://github.com/wp-cli/search-replace-command/pull/30/files/4d16b3163a4ef8d424e73aa74aba1b8c804508ef#r136037981