### PR TITLE
Search slash example no longer needs escaping.

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -792,7 +792,7 @@ class DB_Command extends WP_CLI_Command {
 	 *         ...
 	 *
 	 *     # Search through the database for the 'https?://' regular expression, printing stats.
-	 *     $ wp db search 'https?:\/\/' --regex --stats
+	 *     $ wp db search 'https?://' --regex --stats
 	 *     wp_comments:comment_author_url
 	 *     1:https://wordpress.org/
 	 *         ...


### PR DESCRIPTION
Related https://github.com/wp-cli/db-command/pull/46

Removes escaping from search regex example `https?://`.