### PR TITLE
Lessen context duplication in db search.

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -974,8 +974,8 @@ Feature: Search through the database
   Scenario: Search with large data
     Given a WP install
     # Note "_utf8 X'CC88'" is combining umlaut. Doing it this way as non-ASCII stuff gets stripped due to (eventually) been put thru `escapeshellarg()` with a default C locale.
-    # Also restricted by MySQL's default `max_allowed_packet` size to 16 MB - 1 (0xFFFFFF).
-    And I run `wp db query "INSERT INTO wp_options (option_name, option_value) VALUES ('opt_large', CONCAT(REPEAT('a', 1024 * 1024 * 16 - 9), 'o', _utf8 X'CC88', 'XYXYX'));"`
+    # Also restricted by default MySQL values for the version-dependent size of the innodb redo log file (max 10% one transaction) and `max_allowed_packet` size (16MB).
+    And I run `wp db query "INSERT INTO wp_options (option_name, option_value) VALUES ('opt_large', CONCAT(REPEAT('a', 1024 * 1024 * 8 - 9), 'o', _utf8 X'CC88', 'XYXYX'));"`
 
     When I run `wp db search XYXYX --before_context=1 --stats`
     Then STDOUT should contain:


### PR DESCRIPTION
Related issue #54 and PRs https://github.com/wp-cli/search-replace-command/pull/35 and https://github.com/wp-cli/php-cli-tools/pull/123

Lessens context duplication in `db search` by shortening and appending context if it overlaps with the next match.

This duplicates the loop logic in `search-replace --log` by using a `$last_offset`, which improves output and performance.

Also adds the re-check of encoding per value done in that PR so as not to mistakenly detect all legacy-encoded input as ASCII if the first value happens to be that.

Also exercises the `safe_substr()` fix more by adding test to search with large data.
