### PR TITLE
Avoid displaying default delimiter on regex fail in db search.

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -719,6 +719,34 @@ Feature: Search through the database
       """
     And the return code should be 1
 
+    When I try `wp db search 'regex error)' --regex`
+    Then STDERR should be:
+      """
+      Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and no flags fails.
+      """
+    And the return code should be 1
+
+    When I try `wp db search 'regex error)' --regex --regex-flags=u`
+    Then STDERR should be:
+      """
+      Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and flags 'u' fails.
+      """
+    And the return code should be 1
+
+    When I try `wp db search 'regex error)' --regex --regex-delimiter=/`
+    Then STDERR should be:
+      """
+      Error: The regex '/regex error)/' fails.
+      """
+    And the return code should be 1
+
+    When I try `wp db search 'regex error)' --regex --regex-delimiter=/ --regex-flags=u`
+    Then STDERR should be:
+      """
+      Error: The regex '/regex error)/u' fails.
+      """
+    And the return code should be 1
+
     When I run `wp db search '[0-9é]+?https:' --regex --regex-flags=u --before_context=0 --after_context=0`
     Then STDOUT should contain:
       """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -818,9 +818,11 @@ class DB_Command extends WP_CLI_Command {
 
 		if ( ( $regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false ) ) ) {
 			$regex_flags = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
-			$regex_delimiter = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', chr( 1 ) );
+			$default_regex_delimiter = false;
+			$regex_delimiter = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '' );
 			if ( '' === $regex_delimiter ) {
 				$regex_delimiter = chr( 1 );
+				$default_regex_delimiter = true;
 			}
 		}
 
@@ -841,7 +843,13 @@ class DB_Command extends WP_CLI_Command {
 				$search_regex .= $regex_flags;
 			}
 			if ( false === @preg_match( $search_regex, '' ) ) {
-				WP_CLI::error( "The regex '$search_regex' fails." );
+				if ( $default_regex_delimiter ) {
+					$flags_msg = $regex_flags ? "flags '$regex_flags'" : "no flags";
+					$msg = "The regex pattern '$search' with default delimiter 'chr(1)' and {$flags_msg} fails.";
+				} else {
+					$msg = "The regex '$search_regex' fails.";
+				}
+				WP_CLI::error( $msg );
 			}
 		} else {
 			$search_regex = '#' . preg_quote( $search, '#' ) . '#i';


### PR DESCRIPTION
Related https://github.com/wp-cli/db-command/pull/46 and https://github.com/wp-cli/search-replace-command/pull/30

Avoids displaying default delimiter on regex fail in db search.

If a regex contains an error, then the message displayed appears like this in the default Gnome Terminal on Ubuntu 17.04:

![regex_fail_default_before](https://user-images.githubusercontent.com/481982/31550922-d34b6918-b02a-11e7-9e6e-e8470f0d8cbd.png)

and probably doesn't look any better in other environments.

This PR "spells out" the error message when using the default delimiter, eg:

![regex_fail_default_after](https://user-images.githubusercontent.com/481982/31551008-1f8e26e4-b02b-11e7-8f91-a5d0946289a8.png)

(A similar PR would need to be done for `search-replace`.)

