### PR TITLE
Convert db command help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,36 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 
 This package implements the following commands:
 
+### wp db
+
+Performs basic database operations using credentials stored in wp-config.php.
+
+~~~
+wp db
+~~~
+
+**EXAMPLES**
+
+    # Create a new database.
+    $ wp db create
+    Success: Database created.
+
+    # Drop an existing database.
+    $ wp db drop --yes
+    Success: Database dropped.
+
+    # Reset the current database.
+    $ wp db reset --yes
+    Success: Database reset.
+
+    # Execute a SQL query stored in a file.
+    $ wp db query < debug.sql
+
+
+
 ### wp db create
 
-Create a new database.
+Creates a new database.
 
 ~~~
 wp db create 
@@ -32,7 +59,7 @@ wp-config.php.
 
 ### wp db drop
 
-Delete the existing database.
+Deletes the existing database.
 
 ~~~
 wp db drop [--yes]
@@ -56,7 +83,7 @@ wp-config.php.
 
 ### wp db reset
 
-Remove all tables from the database.
+Removes all tables from the database.
 
 ~~~
 wp db reset [--yes]
@@ -80,7 +107,7 @@ specified in wp-config.php.
 
 ### wp db check
 
-Check the current status of the database.
+Checks the current status of the database.
 
 ~~~
 wp db check 
@@ -102,7 +129,7 @@ for more details on the `CHECK TABLE` statement.
 
 ### wp db optimize
 
-Optimize the database.
+Optimizes the database.
 
 ~~~
 wp db optimize 
@@ -124,7 +151,7 @@ for more details on the `OPTIMIZE TABLE` statement.
 
 ### wp db prefix
 
-Display the database table prefix.
+Displays the database table prefix.
 
 ~~~
 wp db prefix 
@@ -141,7 +168,7 @@ Display the database table prefix, as defined by the database handler's interpre
 
 ### wp db repair
 
-Repair the database.
+Repairs the database.
 
 ~~~
 wp db repair 
@@ -163,7 +190,7 @@ more details on the `REPAIR TABLE` statement.
 
 ### wp db cli
 
-Open a MySQL console using credentials from wp-config.php
+Opens a MySQL console using credentials from wp-config.php
 
 ~~~
 wp db cli [--database=<database>] [--default-character-set=<character-set>] [--<field>=<value>]
@@ -190,7 +217,7 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--<
 
 ### wp db query
 
-Execute a SQL query against the database.
+Executes a SQL query against the database.
 
 ~~~
 wp db query [<sql>] [--<field>=<value>]
@@ -311,7 +338,7 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 
 ### wp db import
 
-Import a database from a file or from STDIN.
+Imports a database from a file or from STDIN.
 
 ~~~
 wp db import [<file>] [--skip-optimization]
@@ -340,7 +367,7 @@ defined in the SQL.
 
 ### wp db search
 
-Find a string in the database.
+Finds a string in the database.
 
 ~~~
 wp db search <search> [<tables>...] [--network] [--all-tables-with-prefix] [--all-tables] [--before_context=<num>] [--after_context=<num>] [--regex] [--regex-flags=<regex-flags>] [--regex-delimiter=<regex-delimiter>] [--table_column_once] [--one_line] [--matches_only] [--stats] [--table_column_color=<color_code>] [--id_color=<color_code>] [--match_color=<color_code>]
@@ -468,7 +495,7 @@ They can be concatenated. For instance, the default match color of black on a mu
 
 ### wp db tables
 
-List the database tables.
+Lists the database tables.
 
 ~~~
 wp db tables [<table>...] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables] [--format=<format>]
@@ -524,7 +551,7 @@ Defaults to all tables registered to the $wpdb database handler.
 
 ### wp db size
 
-Display the database name and size.
+Displays the database name and size.
 
 ~~~
 wp db size [--size_format] [--tables] [--format] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables]

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         },
         "bundled": true,
         "commands": [
+            "db",
             "db create",
             "db drop",
             "db reset",

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -3,7 +3,7 @@
 use \WP_CLI\Utils;
 
 /**
- * Perform basic database operations using credentials stored in wp-config.php
+ * Performs basic database operations using credentials stored in wp-config.php.
  *
  * ## EXAMPLES
  *
@@ -27,7 +27,7 @@ use \WP_CLI\Utils;
 class DB_Command extends WP_CLI_Command {
 
 	/**
-	 * Create a new database.
+	 * Creates a new database.
 	 *
 	 * Runs `CREATE_DATABASE` SQL statement using `DB_HOST`, `DB_NAME`,
 	 * `DB_USER` and `DB_PASSWORD` database credentials specified in
@@ -46,7 +46,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete the existing database.
+	 * Deletes the existing database.
 	 *
 	 * Runs `DROP_DATABASE` SQL statement using `DB_HOST`, `DB_NAME`,
 	 * `DB_USER` and `DB_PASSWORD` database credentials specified in
@@ -71,7 +71,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Remove all tables from the database.
+	 * Removes all tables from the database.
 	 *
 	 * Runs `DROP_DATABASE` and `CREATE_DATABASE` SQL statements using
 	 * `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` database credentials
@@ -97,7 +97,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check the current status of the database.
+	 * Checks the current status of the database.
 	 *
 	 * Runs `mysqlcheck` utility with `--check` using `DB_HOST`,
 	 * `DB_NAME`, `DB_USER` and `DB_PASSWORD` database credentials
@@ -120,7 +120,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Optimize the database.
+	 * Optimizes the database.
 	 *
 	 * Runs `mysqlcheck` utility with `--optimize=true` using `DB_HOST`,
 	 * `DB_NAME`, `DB_USER` and `DB_PASSWORD` database credentials
@@ -143,7 +143,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Repair the database.
+	 * Repairs the database.
 	 *
 	 * Runs `mysqlcheck` utility with `--repair=true` using `DB_HOST`,
 	 * `DB_NAME`, `DB_USER` and `DB_PASSWORD` database credentials
@@ -166,7 +166,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Open a MySQL console using credentials from wp-config.php
+	 * Opens a MySQL console using credentials from wp-config.php
 	 *
 	 * ## OPTIONS
 	 *
@@ -196,7 +196,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Execute a SQL query against the database.
+	 * Executes a SQL query against the database.
 	 *
 	 * Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 	 *  and `DB_PASSWORD` database credentials specified in wp-config.php.
@@ -374,7 +374,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Import a database from a file or from STDIN.
+	 * Imports a database from a file or from STDIN.
 	 *
 	 * Runs SQL queries using `DB_HOST`, `DB_NAME`, `DB_USER` and
 	 * `DB_PASSWORD` database credentials specified in wp-config.php. This
@@ -424,7 +424,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List the database tables.
+	 * Lists the database tables.
 	 *
 	 * Defaults to all tables registered to the $wpdb database handler.
 	 *
@@ -495,7 +495,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Display the database name and size.
+	 * Displays the database name and size.
 	 *
 	 * Display the database name and size for `DB_NAME` specified in wp-config.php.
 	 * The size defaults to a human-readable number.
@@ -671,7 +671,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Display the database table prefix.
+	 * Displays the database table prefix.
 	 *
 	 * Display the database table prefix, as defined by the database handler's interpretation of the current site.
 	 *
@@ -689,7 +689,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Find a string in the database.
+	 * Finds a string in the database.
 	 *
 	 * Searches through all or a selection of database tables for a given string, Outputs colorized references to the string.
 	 *
@@ -1022,7 +1022,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the column names of a db table differentiated into key columns and text columns and all columns.
+	 * Gets the column names of a db table differentiated into key columns and text columns and all columns.
 	 *
 	 * @param string $table The table name.
 	 * @return array A 3 element array consisting of an array of primary key column names, an array of text column names, and an array containing all column names.
@@ -1049,7 +1049,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Whether a column is considered text or not.
+	 * Determines whether a column is considered text or not.
 	 *
 	 * @param string Column type.
 	 * @bool True if text column, false otherwise.


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for db commands and subcommands to use third-person singular verbs.