### PR TITLE
Default value of size_format flag is incorrect #64

### DIFF
--- a/features/db-size.feature
+++ b/features/db-size.feature
@@ -13,7 +13,7 @@ Feature: Display database size
 
     And STDOUT should contain:
       """
-      KB
+      B
       """
 
   Scenario: Display only table sizes for a WordPress install
@@ -22,7 +22,7 @@ Feature: Display database size
     When I run `wp db size --tables`
     Then STDOUT should contain:
       """
-      wp_posts	80 KB
+      wp_posts	81920 B
       """
 
     But STDOUT should not contain:

--- a/features/db-tables.feature
+++ b/features/db-tables.feature
@@ -54,7 +54,6 @@ Feature: List database tables
       wp_signups
       wp_site
       wp_sitemeta
-      wp_sitecategories
       wp_registration_log
       wp_blog_versions
       """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -575,100 +575,100 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * @when after_wp_load
 	 */
-	 public function size( $args, $assoc_args ) {
+	public function size( $args, $assoc_args ) {
 
- 		global $wpdb;
+		global $wpdb;
 
- 		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
- 		$size_format = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
- 		$tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
- 		$tables = ! empty( $tables );
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
+		$size_format = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
+		$tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
+		$tables = ! empty( $tables );
 
- 		unset( $assoc_args['format'] );
- 		unset( $assoc_args['size_format'] );
- 		unset( $assoc_args['tables'] );
+		unset( $assoc_args['format'] );
+		unset( $assoc_args['size_format'] );
+		unset( $assoc_args['tables'] );
 
- 		if ( empty( $args ) && empty( $assoc_args ) ) {
- 			$assoc_args['scope'] = 'all';
- 		}
+		if ( empty( $args ) && empty( $assoc_args ) ) {
+			$assoc_args['scope'] = 'all';
+		}
 
- 		// Build rows for the formatter.
- 		$rows = array();
- 		$fields = array( 'Name', 'Size' );
+		// Build rows for the formatter.
+		$rows = array();
+		$fields = array( 'Name', 'Size' );
 
- 		if ( $tables ) {
+		if ( $tables ) {
 
- 			// Add all of the table sizes
- 			foreach( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
+			// Add all of the table sizes
+			foreach( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
 
- 				// Get the table size.
- 				$table_bytes = $wpdb->get_var( $wpdb->prepare(
- 					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
- 					DB_NAME,
- 					$table_name
- 					)
- 				);
+				// Get the table size.
+				$table_bytes = $wpdb->get_var( $wpdb->prepare(
+					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
+					DB_NAME,
+					$table_name
+					)
+				);
 
- 				// Add the table size to the list.
- 				$rows[] = array(
- 					'Name'  => $table_name,
- 					'Size'  => strtoupper( $table_bytes ) . " " . 'B',
- 				);
- 			}
- 		} else {
+				// Add the table size to the list.
+				$rows[] = array(
+					'Name'  => $table_name,
+					'Size'  => strtoupper( $table_bytes ) . " " . 'B',
+				);
+			}
+		} else {
 
- 			// Get the database size.
- 			$db_bytes = $wpdb->get_var( $wpdb->prepare(
- 				"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
- 				DB_NAME
- 				)
- 			);
+			// Get the database size.
+			$db_bytes = $wpdb->get_var( $wpdb->prepare(
+				"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
+				DB_NAME
+				)
+			);
 
- 			// Add the database size to the list.
- 			$rows[] = array(
- 				'Name'  => DB_NAME,
- 				'Size'  => strtoupper( $db_bytes ) . " " . 'B',
- 				);
- 		}
+			// Add the database size to the list.
+			$rows[] = array(
+				'Name'  => DB_NAME,
+				'Size'  => strtoupper( $db_bytes ) . " " . 'B',
+				);
+		}
 
- 		if ( ! empty( $size_format ) ) {
- 			foreach( $rows as $index => $row ) {
- 					// These added WP 4.4.0.
- 					if ( ! defined( 'KB_IN_BYTES' ) ) {
- 						define( 'KB_IN_BYTES', 1024 );
- 					}
- 					if ( ! defined( 'MB_IN_BYTES' ) ) {
- 						define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
- 					}
+		if ( ! empty( $size_format ) ) {
+			foreach( $rows as $index => $row ) {
+					// These added WP 4.4.0.
+					if ( ! defined( 'KB_IN_BYTES' ) ) {
+						define( 'KB_IN_BYTES', 1024 );
+					}
+					if ( ! defined( 'MB_IN_BYTES' ) ) {
+						define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
+					}
 
- 					// Display the database size as a number.
- 					switch( $size_format ) {
- 						case 'mb':
- 							$divisor = MB_IN_BYTES;
- 							break;
+					// Display the database size as a number.
+					switch( $size_format ) {
+						case 'mb':
+							$divisor = MB_IN_BYTES;
+							break;
 
- 						case 'kb':
- 							$divisor = KB_IN_BYTES;
- 							break;
+						case 'kb':
+							$divisor = KB_IN_BYTES;
+							break;
 
- 						case 'b':
- 						default:
- 							$divisor = 1;
- 							break;
- 					}
+						case 'b':
+						default:
+							$divisor = 1;
+							break;
+					}
 
- 					$rows[ $index ]['Size'] = $row['Size'] / $divisor . " " . ucfirst( $size_format );
- 			}
- 		}
+					$rows[ $index ]['Size'] = $row['Size'] / $divisor . " " . ucfirst( $size_format );
+			}
+		}
 
- 		// Display the rows.
- 		$args = array(
- 			'format' => $format,
- 		);
+		// Display the rows.
+		$args = array(
+			'format' => $format,
+		);
 
- 		$formatter = new \WP_CLI\Formatter( $args, $fields );
- 		$formatter->display_items( $rows );
- 	}
+		$formatter = new \WP_CLI\Formatter( $args, $fields );
+		$formatter->display_items( $rows );
+	}
 
 	/**
 	 * Displays the database table prefix.

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -575,100 +575,100 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * @when after_wp_load
 	 */
-	public function size( $args, $assoc_args ) {
+	 public function size( $args, $assoc_args ) {
 
-		global $wpdb;
+ 		global $wpdb;
 
-		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
-		$size_format = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
-		$tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
-		$tables = ! empty( $tables );
+ 		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
+ 		$size_format = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
+ 		$tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
+ 		$tables = ! empty( $tables );
 
-		unset( $assoc_args['format'] );
-		unset( $assoc_args['size_format'] );
-		unset( $assoc_args['tables'] );
+ 		unset( $assoc_args['format'] );
+ 		unset( $assoc_args['size_format'] );
+ 		unset( $assoc_args['tables'] );
 
-		if ( empty( $args ) && empty( $assoc_args ) ) {
-			$assoc_args['scope'] = 'all';
-		}
+ 		if ( empty( $args ) && empty( $assoc_args ) ) {
+ 			$assoc_args['scope'] = 'all';
+ 		}
 
-		// Build rows for the formatter.
-		$rows = array();
-		$fields = array( 'Name', 'Size' );
+ 		// Build rows for the formatter.
+ 		$rows = array();
+ 		$fields = array( 'Name', 'Size' );
 
-		if ( $tables ) {
+ 		if ( $tables ) {
 
-			// Add all of the table sizes
-			foreach( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
+ 			// Add all of the table sizes
+ 			foreach( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
 
-				// Get the table size.
-				$table_bytes = $wpdb->get_var( $wpdb->prepare(
-					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
-					DB_NAME,
-					$table_name
-					)
-				);
+ 				// Get the table size.
+ 				$table_bytes = $wpdb->get_var( $wpdb->prepare(
+ 					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
+ 					DB_NAME,
+ 					$table_name
+ 					)
+ 				);
 
-				// Add the table size to the list.
-				$rows[] = array(
-					'Name'  => $table_name,
-					'Size'  => strtoupper( size_format( $table_bytes ) ),
-				);
-			}
-		} else {
+ 				// Add the table size to the list.
+ 				$rows[] = array(
+ 					'Name'  => $table_name,
+ 					'Size'  => strtoupper( $table_bytes ) . " " . 'B',
+ 				);
+ 			}
+ 		} else {
 
-			// Get the database size.
-			$db_bytes = $wpdb->get_var( $wpdb->prepare(
-				"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
-				DB_NAME
-				)
-			);
+ 			// Get the database size.
+ 			$db_bytes = $wpdb->get_var( $wpdb->prepare(
+ 				"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
+ 				DB_NAME
+ 				)
+ 			);
 
-			// Add the database size to the list.
-			$rows[] = array(
-				'Name'  => DB_NAME,
-				'Size'  => strtoupper( size_format( $db_bytes ) ),
-				);
-		}
+ 			// Add the database size to the list.
+ 			$rows[] = array(
+ 				'Name'  => DB_NAME,
+ 				'Size'  => strtoupper( $db_bytes ) . " " . 'B',
+ 				);
+ 		}
 
-		if ( ! empty( $size_format ) && isset( $db_bytes ) && ! $tables ) {
+ 		if ( ! empty( $size_format ) ) {
+ 			foreach( $rows as $index => $row ) {
+ 					// These added WP 4.4.0.
+ 					if ( ! defined( 'KB_IN_BYTES' ) ) {
+ 						define( 'KB_IN_BYTES', 1024 );
+ 					}
+ 					if ( ! defined( 'MB_IN_BYTES' ) ) {
+ 						define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
+ 					}
 
-			// These added WP 4.4.0.
-			if ( ! defined( 'KB_IN_BYTES' ) ) {
-				define( 'KB_IN_BYTES', 1024 );
-			}
-			if ( ! defined( 'MB_IN_BYTES' ) ) {
-				define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
-			}
+ 					// Display the database size as a number.
+ 					switch( $size_format ) {
+ 						case 'mb':
+ 							$divisor = MB_IN_BYTES;
+ 							break;
 
-			// Display the database size as a number.
-			switch( $size_format ) {
-				case 'mb':
-					$divisor = MB_IN_BYTES;
-					break;
+ 						case 'kb':
+ 							$divisor = KB_IN_BYTES;
+ 							break;
 
-				case 'kb':
-					$divisor = KB_IN_BYTES;
-					break;
+ 						case 'b':
+ 						default:
+ 							$divisor = 1;
+ 							break;
+ 					}
 
-				case 'b':
-				default:
-					$divisor = 1;
-					break;
-			}
+ 					$rows[ $index ]['Size'] = $row['Size'] / $divisor . " " . ucfirst( $size_format );
+ 			}
+ 		}
 
-			WP_CLI::Line( ceil( $db_bytes / $divisor ) );
-		} else {
+ 		// Display the rows.
+ 		$args = array(
+ 			'format' => $format,
+ 		);
 
-			// Display the rows.
-			$args = array(
-				'format' => $format,
-			);
-
-			$formatter = new \WP_CLI\Formatter( $args, $fields );
-			$formatter->display_items( $rows );
-		}
-	}
+ 		$formatter = new \WP_CLI\Formatter( $args, $fields );
+ 		$formatter->display_items( $rows );
+ 	}
 
 	/**
 	 * Displays the database table prefix.

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -596,6 +596,8 @@ class DB_Command extends WP_CLI_Command {
 		$rows = array();
 		$fields = array( 'Name', 'Size' );
 
+		$default_unit = ( empty( $size_format ) ) ? ' B' : '';
+
 		if ( $tables ) {
 
 			// Add all of the table sizes
@@ -612,7 +614,7 @@ class DB_Command extends WP_CLI_Command {
 				// Add the table size to the list.
 				$rows[] = array(
 					'Name'  => $table_name,
-					'Size'  => strtoupper( $table_bytes ) . " " . 'B',
+					'Size'  => strtoupper( $table_bytes ) . $default_unit,
 				);
 			}
 		} else {
@@ -627,7 +629,7 @@ class DB_Command extends WP_CLI_Command {
 			// Add the database size to the list.
 			$rows[] = array(
 				'Name'  => DB_NAME,
-				'Size'  => strtoupper( $db_bytes ) . " " . 'B',
+				'Size'  => strtoupper( $db_bytes ) . $default_unit,
 				);
 		}
 
@@ -657,17 +659,21 @@ class DB_Command extends WP_CLI_Command {
 							break;
 					}
 
-					$rows[ $index ]['Size'] = $row['Size'] / $divisor . " " . ucfirst( $size_format );
+					$rows[ $index ]['Size'] = ceil( $row['Size'] / $divisor ) . " " . strtoupper( $size_format );
 			}
 		}
 
-		// Display the rows.
-		$args = array(
-			'format' => $format,
-		);
+		if ( ! empty( $size_format) && ! $tables ) {
+			WP_CLI::Line( filter_var( $rows[0]['Size'], FILTER_SANITIZE_NUMBER_INT ) );
+		} else {
+			// Display the rows.
+			$args = array(
+				'format' => $format,
+			);
 
-		$formatter = new \WP_CLI\Formatter( $args, $fields );
-		$formatter->display_items( $rows );
+			$formatter = new \WP_CLI\Formatter( $args, $fields );
+			$formatter->display_items( $rows );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Default value of size_format flag is incorrect https://github.com/wp-cli/db-command/issues/64
- Implemented a method to make the default value always be in bytes;
- Implemented a generalized method to calc the size when `--size_format` is provided, which now will also calculate even when `--tables` is provided.