### PR TITLE
Remove `wp_sitecategories` from list of standard MS tables

### DIFF
--- a/features/db-tables.feature
+++ b/features/db-tables.feature
@@ -54,7 +54,6 @@ Feature: List database tables
       wp_signups
       wp_site
       wp_sitemeta
-      wp_sitecategories
       wp_registration_log
       wp_blog_versions
       """


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4552
Causing #68 to break