### PR TITLE
Add example of how to search and delete results #51

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -264,9 +264,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:http://example.com
-      wp_options:option_value
-      2:http://example.com
+      http://example.com
       Success: Record deleted!
       """
     And STDERR should contain:

--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -263,8 +263,14 @@ Feature: Search through the database
     When I try `wp db search "^http://example.com$" --regex --delete-records --yes`
     Then STDOUT should contain:
       """
-      wp_options:option_value
       http://example.com
+      """
+    And STDOUT should contain:
+      """
+      wp_options:option_value
+      """
+    And STDOUT should contain:
+      """
       Success: Record deleted!
       """
     And STDERR should contain:

--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -260,16 +260,20 @@ Feature: Search through the database
       """
     And the return code should be 0
 
-    When I run `wp db search example.com --delete-records`
+    When I try `wp db search "^http://example.com$" --regex --delete-records --yes`
     Then STDOUT should contain:
       """
       wp_options:option_value
+      1:http://example.com
+      wp_options:option_value
       2:http://example.com
+      Success: Record deleted!
       """
     And STDERR should contain:
       """
       Warning: Removing this record could break your site, skipping the deletion.
       """
+    And the return code should be 0
 
   Scenario: Search on a multisite install
     Given a WP multisite install

--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -260,6 +260,17 @@ Feature: Search through the database
       """
     And the return code should be 0
 
+    When I run `wp db search example.com --delete-records`
+    Then STDOUT should contain:
+      """
+      wp_options:option_value
+      2:http://example.com
+      """
+    And STDERR should contain:
+      """
+      Warning: Removing this record could break your site, skipping the deletion.
+      """
+
   Scenario: Search on a multisite install
     Given a WP multisite install
     And I run `wp site create --slug=foo`

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -967,8 +967,8 @@ class DB_Command extends WP_CLI_Command {
 
 							WP_CLI::log( $matches_only ? $col_val : ( $one_line ? "{$table_column_val}:{$pk_val}{$col_val}" : "{$pk_val}{$col_val}" ) );
 
-							if ( true == $delete_records ) {
-								if ( ! empty( $primary_key ) ) {
+							if ( $delete_records ) {
+								if ( ! empty( $column_sql ) ) {
 									if ( $wpdb->prefix . 'options' == $table && 1 == $result->$primary_key ) {
 										WP_CLI::warning( "Removing this record could break your site, skipping the deletion." );
 									} else {
@@ -976,7 +976,7 @@ class DB_Command extends WP_CLI_Command {
 											$primary_key => $result->$primary_key,
 										) );
 
-										WP_CLI::warning( "Record deleted!" );
+										WP_CLI::success( "Record deleted!" );
 									}
 								} else {
 									WP_CLI::warning( "No primary key for this record, skipping the deletion." );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -751,6 +751,10 @@ class DB_Command extends WP_CLI_Command {
 	 * [--id_color=<color_code>]
 	 * : Percent color code to use for the row id output. For a list of available percent color codes, see below. Default '%Y' (bright yellow).
 	 *
+	 *
+	 * [--delete-records]
+	 * : Delete the record found from database.
+
 	 * [--match_color=<color_code>]
 	 * : Percent color code to use for the match (unless both before and after context are 0, when no color code is used). For a list of available percent color codes, see below. Default '%3%k' (black on a mustard background).
 	 *
@@ -840,6 +844,7 @@ class DB_Command extends WP_CLI_Command {
 		$one_line = \WP_CLI\Utils\get_flag_value( $assoc_args, 'one_line', false );
 		$matches_only = \WP_CLI\Utils\get_flag_value( $assoc_args, 'matches_only', false );
 		$stats = \WP_CLI\Utils\get_flag_value( $assoc_args, 'stats', false );
+		$delete_records = \WP_CLI\Utils\get_flag_value( $assoc_args, 'delete-records', false );
 
 		$column_count = $row_count = $match_count = 0;
 		$skipped = array();
@@ -961,6 +966,22 @@ class DB_Command extends WP_CLI_Command {
 							$col_val = implode( ' [...] ', $bits );
 
 							WP_CLI::log( $matches_only ? $col_val : ( $one_line ? "{$table_column_val}:{$pk_val}{$col_val}" : "{$pk_val}{$col_val}" ) );
+
+							if ( true == $delete_records ) {
+								if ( ! empty( $primary_key ) ) {
+									if ( $wpdb->prefix . 'options' == $table && 1 == $result->$primary_key ) {
+										WP_CLI::warning( "Removing this record could break your site, skipping the deletion." );
+									} else {
+										$wpdb->delete( $table, array(
+											$primary_key => $result->$primary_key,
+										) );
+
+										WP_CLI::warning( "Record deleted!" );
+									}
+								} else {
+									WP_CLI::warning( "No primary key for this record, skipping the deletion." );
+								}
+							}
 						}
 					}
 				}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -754,7 +754,10 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--delete-records]
 	 * : Delete the record found from database.
-
+	 *
+	 * [--yes]
+	 * : Answer yes to the confirmation message.
+	 *
 	 * [--match_color=<color_code>]
 	 * : Percent color code to use for the match (unless both before and after context are 0, when no color code is used). For a list of available percent color codes, see below. Default '%3%k' (black on a mustard background).
 	 *
@@ -845,6 +848,10 @@ class DB_Command extends WP_CLI_Command {
 		$matches_only = \WP_CLI\Utils\get_flag_value( $assoc_args, 'matches_only', false );
 		$stats = \WP_CLI\Utils\get_flag_value( $assoc_args, 'stats', false );
 		$delete_records = \WP_CLI\Utils\get_flag_value( $assoc_args, 'delete-records', false );
+
+		if ( $delete_records ) {
+			WP_CLI::confirm( 'Are you sure you want to delete the records found by this search?', $assoc_args );
+		}
 
 		$column_count = $row_count = $match_count = 0;
 		$skipped = array();
@@ -970,16 +977,16 @@ class DB_Command extends WP_CLI_Command {
 							if ( $delete_records ) {
 								if ( ! empty( $column_sql ) ) {
 									if ( $wpdb->prefix . 'options' == $table && 1 == $result->$primary_key ) {
-										WP_CLI::warning( "Removing this record could break your site, skipping the deletion." );
+										WP_CLI::warning( 'Removing this record could break your site, skipping the deletion.' );
 									} else {
 										$wpdb->delete( $table, array(
 											$primary_key => $result->$primary_key,
 										) );
 
-										WP_CLI::success( "Record deleted!" );
+										WP_CLI::success( 'Record deleted!' );
 									}
 								} else {
-									WP_CLI::warning( "No primary key for this record, skipping the deletion." );
+									WP_CLI::warning( 'No primary key for this record, skipping the deletion.' );
 								}
 							}
 						}


### PR DESCRIPTION
### Add a `--delete-records` to `wp db search`
 - Implemented a new argument `--delete-records` that deletes each entry found by `wp db search`