### PR TITLE
Use Utils\esc_like() and remove internal esc_like().

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "files": [ "db-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "*"
+        "wp-cli/wp-cli": ">=1.5.0"
     },
     "require-dev": {
         "behat/behat": "~2.5"

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -947,7 +947,7 @@ class DB_Command extends WP_CLI_Command {
 			}
 		} else {
 			$search_regex = '#' . preg_quote( $search, '#' ) . '#i';
-			$esc_like_search = '%' . self::esc_like( $search ) . '%';
+			$esc_like_search = '%' . Utils\esc_like( $search ) . '%';
 		}
 
 		$encoding = null;
@@ -1174,27 +1174,6 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Escapes a MySQL string for inclusion in a `LIKE` clause. BC wrapper around different WP versions of this.
-	 *
-	 * @param string $old String to escape.
-	 * @param string Escaped string.
-	 */
-	private static function esc_like( $old ) {
-		global $wpdb;
-
-		// Remove notices in 4.0 and support backwards compatibility
-		if ( method_exists( $wpdb, 'esc_like' ) ) {
-			// 4.0
-			$old = $wpdb->esc_like( $old );
-		} else {
-			// 3.9 or less
-			$old = like_escape( esc_sql( $old ) );
-		}
-
-		return $old;
 	}
 
 	/**


### PR DESCRIPTION
Closes #66

Related #65 and https://github.com/wp-cli/wp-cli/pull/4612

Uses new `Utils\esc_like()` and removes `DB_Command::esc_like()`.

Changes require of `wp-cli/wp-cli` to `>=1.5.0` in `composer.json` (is this the right way to do this? `>=` seems to work as uses `dev-master` whereas using caret or tilde fails with "Your requirements could not be resolved to an installable set of packages.").