### PR TITLE
Feature/db reset using table prefix

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -106,18 +106,18 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 *     $ wp db reset --yes
 	 *     Success: Database reset.
+	 *
+	 * @when after_wp_load
 	 */
 	public function reset( $_, $assoc_args ) {
-		global $wpdb;
-
 		WP_CLI::confirm( "Are you sure you want to reset the '" . DB_NAME . "' database?", $assoc_args );
 
-		$tables = WP_CLI\Utils\wp_get_table_names( $wpdb->prefix );
+		$tables = WP_CLI\Utils\wp_get_table_names( array(), array( 'all-tables-with-prefix' ) );
 
 		$mysql_args = self::get_dbuser_dbpass_args( $assoc_args );
 
 		foreach ( $tables as $table ) {
-			self::run_query( sprintf( 'DROP TABLE IF EXISTS `%s`', $table ), $mysql_args );
+			self::run_query( sprintf( 'DROP TABLE IF EXISTS `%s`.`%s`', DB_NAME, $table ), $mysql_args );
 		}
 
 		WP_CLI::success( "Database reset." );
@@ -577,6 +577,7 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		$tables = WP_CLI\Utils\wp_get_table_names( $args, $assoc_args );
+		$tables = WP_CLI\Utils\wp_get_table_names( $args );
 
 		if ( 'csv' === $format ) {
 			WP_CLI::line( implode( ',', $tables ) );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -68,6 +68,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--dbpass=<value>]
 	 * : Password to pass to mysql. Defaults to DB_PASSWORD.
 	 *
+	 * [--re-create]
+	 * : Recreates the database.
+	 *
 	 * [--yes]
 	 * : Answer yes to the confirmation message.
 	 *
@@ -79,7 +82,15 @@ class DB_Command extends WP_CLI_Command {
 	public function drop( $_, $assoc_args ) {
 		WP_CLI::confirm( "Are you sure you want to drop the '" . DB_NAME . "' database?", $assoc_args );
 
-		self::run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ), self::get_dbuser_dbpass_args( $assoc_args ) );
+		$mysql_args = self::get_dbuser_dbpass_args( $assoc_args );
+
+		self::run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ), $mysql_args );
+
+		$recreate = \WP_CLI\Utils\get_flag_value( $assoc_args, 're-create' );
+
+		if ( $recreate ) {
+			self::run_query( self::get_create_query(), $mysql_args );
+		}
 
 		WP_CLI::success( "Database dropped." );
 	}


### PR DESCRIPTION
### Makes `wp db reset` remove only tables with $table_prefix (issue https://github.com/wp-cli/db-command/issues/87)
 - Changed from `DROP DATABASE` to `DROP TABLE` for each table in the database that has `$table_prefix`;
 - Added a new flat `--re-create` on `wp db drop`, so we keep the drop and create database functionality.
