### PR TITLE
Fix `--size_format` argument definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Defaults to all tables registered to the $wpdb database handler.
 Displays the database name and size.
 
 ~~~
-wp db size [--size_format=<format>] [--tables] [--human-readable] [--format] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables]
+wp db size [--size_format=<format>] [--tables] [--human-readable] [--format=<format>] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables]
 ~~~
 
 Display the database name and size for `DB_NAME` specified in wp-config.php.
@@ -723,14 +723,15 @@ Available size formats include:
 	[--human-readable]
 		Display database sizes in human readable formats.
 
-	[--format]
-		table, csv, json
+	[--format=<format>]
+		Render output in a particular format.
 		---
 		default: table
 		options:
 		  - table
 		  - csv
 		  - json
+		  - yaml
 		---
 
 	[--scope=<scope>]

--- a/README.md
+++ b/README.md
@@ -678,6 +678,22 @@ wp db size [--size_format=<format>] [--tables] [--human-readable] [--format] [--
 Display the database name and size for `DB_NAME` specified in wp-config.php.
 The size defaults to a human-readable number.
 
+Available size formats include:
+* b (bytes)
+* kb (kilobytes)
+* mb (megabytes)
+* gb (gigabytes)
+* tb (terabytes)
+* B   (ISO Byte setting, with no conversion)
+* KB  (ISO Kilobyte setting, with 1 KB  = 1,000 B)
+* KiB (ISO Kibibyte setting, with 1 KiB = 1,024 B)
+* MB  (ISO Megabyte setting, with 1 MB  = 1,000 KB)
+* MiB (ISO Mebibyte setting, with 1 MiB = 1,024 KiB)
+* GB  (ISO Gigabyte setting, with 1 GB  = 1,000 MB)
+* GiB (ISO Gibibyte setting, with 1 GiB = 1,024 MiB)
+* TB  (ISO Terabyte setting, with 1 TB  = 1,000 GB)
+* TiB (ISO Tebibyte setting, with 1 TiB = 1,024 GiB)
+
 **OPTIONS**
 
 	[--size_format=<format>]
@@ -685,20 +701,20 @@ The size defaults to a human-readable number.
 		---
 		default: b
 		options:
-		 - b (bytes)
-		 - kb (kilobytes)
-		 - mb (megabytes)
-		 - gb (gigabytes)
-		 - tb (terabytes)
-		 - B   (ISO Byte setting, with no conversion)
-		 - KB  (ISO Kilobyte setting, with 1 KB  = 1,000 B)
-		 - KiB (ISO Kibibyte setting, with 1 KiB = 1,024 B)
-		 - MB  (ISO Megabyte setting, with 1 MB  = 1,000 KB)
-		 - MiB (ISO Mebibyte setting, with 1 MiB = 1,024 KiB)
-		 - GB  (ISO Gigabyte setting, with 1 GB  = 1,000 MB)
-		 - GiB (ISO Gibibyte setting, with 1 GiB = 1,024 MiB)
-		 - TB  (ISO Terabyte setting, with 1 TB  = 1,000 GB)
-		 - TiB (ISO Tebibyte setting, with 1 TiB = 1,024 GiB)
+		 - b
+		 - kb
+		 - mb
+		 - gb
+		 - tb
+		 - B
+		 - KB
+		 - KiB
+		 - MB
+		 - MiB
+		 - GB
+		 - GiB
+		 - TB
+		 - TiB
 		 ---
 
 	[--tables]

--- a/README.md
+++ b/README.md
@@ -738,7 +738,6 @@ Available size formats include:
 	[--format=<format>]
 		Render output in a particular format.
 		---
-		default: table
 		options:
 		  - table
 		  - csv

--- a/README.md
+++ b/README.md
@@ -701,21 +701,21 @@ Available size formats include:
 		---
 		default: b
 		options:
-		 - b
-		 - kb
-		 - mb
-		 - gb
-		 - tb
-		 - B
-		 - KB
-		 - KiB
-		 - MB
-		 - MiB
-		 - GB
-		 - GiB
-		 - TB
-		 - TiB
-		 ---
+		  - b
+		  - kb
+		  - mb
+		  - gb
+		  - tb
+		  - B
+		  - KB
+		  - KiB
+		  - MB
+		  - MiB
+		  - GB
+		  - GiB
+		  - TB
+		  - TiB
+		---
 
 	[--tables]
 		Display each table name and size instead of the database size.

--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Defaults to all tables registered to the $wpdb database handler.
 Displays the database name and size.
 
 ~~~
-wp db size [--size_format] [--tables] [--format] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables]
+wp db size [--size_format=<format>] [--tables] [--human-readable] [--format] [--scope=<scope>] [--network] [--all-tables-with-prefix] [--all-tables]
 ~~~
 
 Display the database name and size for `DB_NAME` specified in wp-config.php.
@@ -680,7 +680,7 @@ The size defaults to a human-readable number.
 
 **OPTIONS**
 
-	[--size_format]
+	[--size_format=<format>]
 		Display the database size only, as a bare number.
 		---
 		default: b
@@ -703,6 +703,9 @@ The size defaults to a human-readable number.
 
 	[--tables]
 		Display each table name and size instead of the database size.
+
+	[--human-readable]
+		Display database sizes in human readable formats.
 
 	[--format]
 		table, csv, json

--- a/README.md
+++ b/README.md
@@ -699,7 +699,6 @@ Available size formats include:
 	[--size_format=<format>]
 		Display the database size only, as a bare number.
 		---
-		default: b
 		options:
 		  - b
 		  - kb

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -661,7 +661,7 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--size_format]
+	 * [--size_format=<format>]
 	 * : Display the database size only, as a bare number.
 	 * ---
 	 * default: b

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -682,21 +682,21 @@ class DB_Command extends WP_CLI_Command {
 	 * ---
 	 * default: b
 	 * options:
-	 *  - b
-	 *  - kb
-	 *  - mb
-	 *  - gb
-	 *  - tb
-	 *  - B
-	 *  - KB
-	 *  - KiB
-	 *  - MB
-	 *  - MiB
-	 *  - GB
-	 *  - GiB
-	 *  - TB
-	 *  - TiB
-	 *  ---
+	 *   - b
+	 *   - kb
+	 *   - mb
+	 *   - gb
+	 *   - tb
+	 *   - B
+	 *   - KB
+	 *   - KiB
+	 *   - MB
+	 *   - MiB
+	 *   - GB
+	 *   - GiB
+	 *   - TB
+	 *   - TiB
+	 * ---
 	 *
 	 * [--tables]
 	 * : Display each table name and size instead of the database size.

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -706,7 +706,6 @@ class DB_Command extends WP_CLI_Command {
 	 * [--format=<format>]
 	 * : Render output in a particular format.
 	 * ---
-	 * default: table
 	 * options:
 	 *   - table
 	 *   - csv

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -704,14 +704,15 @@ class DB_Command extends WP_CLI_Command {
 	 * [--human-readable]
 	 * : Display database sizes in human readable formats.
 	 *
-	 * [--format]
-	 * : table, csv, json
+	 * [--format=<format>]
+	 * : Render output in a particular format.
 	 * ---
 	 * default: table
 	 * options:
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - yaml
 	 * ---
 	 *
 	 * [--scope=<scope>]

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -659,6 +659,22 @@ class DB_Command extends WP_CLI_Command {
 	 * Display the database name and size for `DB_NAME` specified in wp-config.php.
 	 * The size defaults to a human-readable number.
 	 *
+	 * Available size formats include:
+	 * * b (bytes)
+	 * * kb (kilobytes)
+	 * * mb (megabytes)
+	 * * gb (gigabytes)
+	 * * tb (terabytes)
+	 * * B   (ISO Byte setting, with no conversion)
+	 * * KB  (ISO Kilobyte setting, with 1 KB  = 1,000 B)
+	 * * KiB (ISO Kibibyte setting, with 1 KiB = 1,024 B)
+	 * * MB  (ISO Megabyte setting, with 1 MB  = 1,000 KB)
+	 * * MiB (ISO Mebibyte setting, with 1 MiB = 1,024 KiB)
+	 * * GB  (ISO Gigabyte setting, with 1 GB  = 1,000 MB)
+	 * * GiB (ISO Gibibyte setting, with 1 GiB = 1,024 MiB)
+	 * * TB  (ISO Terabyte setting, with 1 TB  = 1,000 GB)
+	 * * TiB (ISO Tebibyte setting, with 1 TiB = 1,024 GiB)
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--size_format=<format>]
@@ -666,20 +682,20 @@ class DB_Command extends WP_CLI_Command {
 	 * ---
 	 * default: b
 	 * options:
-	 *  - b (bytes)
-	 *  - kb (kilobytes)
-	 *  - mb (megabytes)
-	 *  - gb (gigabytes)
-	 *  - tb (terabytes)
-	 *  - B   (ISO Byte setting, with no conversion)
-	 *  - KB  (ISO Kilobyte setting, with 1 KB  = 1,000 B)
-	 *  - KiB (ISO Kibibyte setting, with 1 KiB = 1,024 B)
-	 *  - MB  (ISO Megabyte setting, with 1 MB  = 1,000 KB)
-	 *  - MiB (ISO Mebibyte setting, with 1 MiB = 1,024 KiB)
-	 *  - GB  (ISO Gigabyte setting, with 1 GB  = 1,000 MB)
-	 *  - GiB (ISO Gibibyte setting, with 1 GiB = 1,024 MiB)
-	 *  - TB  (ISO Terabyte setting, with 1 TB  = 1,000 GB)
-	 *  - TiB (ISO Tebibyte setting, with 1 TiB = 1,024 GiB)
+	 *  - b
+	 *  - kb
+	 *  - mb
+	 *  - gb
+	 *  - tb
+	 *  - B
+	 *  - KB
+	 *  - KiB
+	 *  - MB
+	 *  - MiB
+	 *  - GB
+	 *  - GiB
+	 *  - TB
+	 *  - TiB
 	 *  ---
 	 *
 	 * [--tables]

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -680,7 +680,6 @@ class DB_Command extends WP_CLI_Command {
 	 * [--size_format=<format>]
 	 * : Display the database size only, as a bare number.
 	 * ---
-	 * default: b
 	 * options:
 	 *   - b
 	 *   - kb


### PR DESCRIPTION
It should be `--size_format=<format>` because it's never a flag. From #16.

Also adds `--human-readable` to README docs. From #124.