### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.phpcs.xml
 wp-cli.local.yml
 node_modules/
 vendor/
@@ -6,4 +7,6 @@ vendor/
 *.tar.gz
 .*.swp
 composer.lock
+phpunit.xml
+phpcs.xml
 *.log

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/db-command.php
+++ b/db-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_db_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_db_autoloader ) ) {
+	require_once $wpcli_db_autoloader;
 }
 
 WP_CLI::add_command( 'db', 'DB_Command' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-db">
+	<description>Custom ruleset for WP-CLI db-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\db"/><!-- Namespaces. -->
+				<element value="wpcli_db"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,5 +50,9 @@
 			</property>
 		</properties>
 	</rule>
-
+	
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/DB_Command\.php$</exclude-pattern>
+	</rule>
 </ruleset>

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1509,7 +1509,8 @@ class DB_Command extends WP_CLI_Command {
 		$color_codes_regex = '/^(?:%[' . $color_codes . '])*$/';
 
 		foreach ( array_keys( $colors ) as $color_col ) {
-			if ( false !== ( $col_color_flag = \WP_CLI\Utils\get_flag_value( $assoc_args, $color_col . '_color', false ) ) ) {
+			$col_color_flag = \WP_CLI\Utils\get_flag_value( $assoc_args, $color_col . '_color', false );
+			if ( false !== $col_color_flag ) {
 				if ( ! preg_match( $color_codes_regex, $col_color_flag, $matches ) ) {
 					WP_CLI::warning( "Unrecognized percent color code '$col_color_flag' for '{$color_col}_color'." );
 				} else {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1169,7 +1169,7 @@ class DB_Command extends WP_CLI_Command {
 			$column_count += count( $text_columns );
 			if ( ! $primary_keys ) {
 				WP_CLI::warning( "No primary key for table '$table'. No row ids will be outputted." );
-				$primary_key '';
+				$primary_key     = '';
 				$primary_key_sql = '';
 			} else {
 				$primary_key     = array_shift( $primary_keys );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -207,7 +207,7 @@ class DB_Command extends WP_CLI_Command {
 		$assoc_args['check'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			$assoc_args,
+			$assoc_args
 		);
 
 		WP_CLI::success( 'Database checked.' );
@@ -243,7 +243,7 @@ class DB_Command extends WP_CLI_Command {
 		$assoc_args['optimize'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			$assoc_args,
+			$assoc_args
 		);
 
 		WP_CLI::success( 'Database optimized.' );
@@ -279,7 +279,7 @@ class DB_Command extends WP_CLI_Command {
 		$assoc_args['repair'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			$assoc_args,
+			$assoc_args
 		);
 
 		WP_CLI::success( 'Database repaired.' );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -204,14 +204,10 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database checked.
 	 */
 	public function check( $_, $assoc_args ) {
+		$assoc_args['check'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			array_merge(
-				$assoc_args,
-				array(
-					'check' => true,
-				)
-			)
+			$assoc_args,
 		);
 
 		WP_CLI::success( 'Database checked.' );
@@ -244,14 +240,10 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database optimized.
 	 */
 	public function optimize( $_, $assoc_args ) {
+		$assoc_args['optimize'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			array_merge(
-				$assoc_args,
-				array(
-					'optimize' => true,
-				)
-			)
+			$assoc_args,
 		);
 
 		WP_CLI::success( 'Database optimized.' );
@@ -284,14 +276,10 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database repaired.
 	 */
 	public function repair( $_, $assoc_args ) {
+		$assoc_args['repair'] = true;
 		self::run(
 			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
-			array_merge(
-				$assoc_args,
-				array(
-					'repair' => true,
-				)
-			)
+			$assoc_args,
 		);
 
 		WP_CLI::success( 'Database repaired.' );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -876,7 +876,7 @@ class DB_Command extends WP_CLI_Command {
 						break;
 
 					case 'KB':
-							$divisor = 1000;
+						$divisor = 1000;
 						break;
 
 					case 'tb':

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -875,29 +875,29 @@ class DB_Command extends WP_CLI_Command {
 					// Display the database size as a number.
 				switch ( $size_format ) {
 					case 'TB':
-							 $divisor = pow( 1000, 4 );
+							$divisor = pow( 1000, 4 );
 						break;
 
 					case 'GB':
-							 $divisor = pow( 1000, 3 );
+							$divisor = pow( 1000, 3 );
 						break;
 
 					case 'MB':
-							 $divisor = pow( 1000, 2 );
+							$divisor = pow( 1000, 2 );
 						break;
 
 					case 'KB':
-							 $divisor = 1000;
+							$divisor = 1000;
 						break;
 
 					case 'tb':
 					case 'TiB':
-							 $divisor = TB_IN_BYTES;
+							$divisor = TB_IN_BYTES;
 						break;
 
 					case 'gb':
 					case 'GiB':
-							 $divisor = GB_IN_BYTES;
+							$divisor = GB_IN_BYTES;
 						break;
 
 					case 'mb':
@@ -1102,7 +1102,8 @@ class DB_Command extends WP_CLI_Command {
 		$after_context = \WP_CLI\Utils\get_flag_value( $assoc_args, 'after_context', 40 );
 		$after_context = '' === $after_context ? $after_context : (int) $after_context;
 
-		if ( ( $regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false ) ) ) {
+		$regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false )
+		if ( false !== $regex ) {
 			$regex_flags             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
 			$default_regex_delimiter = false;
 			$regex_delimiter         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '' );
@@ -1126,7 +1127,9 @@ class DB_Command extends WP_CLI_Command {
 		$matches_only      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'matches_only', false );
 		$stats             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'stats', false );
 
-		$column_count = $row_count = $match_count = 0;
+		$column_count = 0;
+		$row_count    = 0;
+		$match_count  = 0
 		$skipped      = array();
 
 		if ( $regex ) {
@@ -1178,7 +1181,8 @@ class DB_Command extends WP_CLI_Command {
 			$column_count += count( $text_columns );
 			if ( ! $primary_keys ) {
 				WP_CLI::warning( "No primary key for table '$table'. No row ids will be outputted." );
-				$primary_key = $primary_key_sql = '';
+				$primary_key '';
+				$primary_key_sql = '';
 			} else {
 				$primary_key     = array_shift( $primary_keys );
 				$primary_key_sql = self::esc_sql_ident( $primary_key ) . ', ';
@@ -1216,7 +1220,8 @@ class DB_Command extends WP_CLI_Command {
 								$match           = $matches[0][ $i ][0];
 								$offset          = $matches[0][ $i ][1];
 								$log             = $colors['match'][0] . $match . $colors['match'][1];
-								$before          = $after = '';
+								$before          = '';
+								after            = '';
 								$after_shortened = false;
 
 								// Offsets are in bytes, so need to use `strlen()` and `substr()` before using `safe_substr()`.
@@ -1407,10 +1412,12 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	private static function get_dbuser_dbpass_args( $assoc_args ) {
 		$mysql_args = array();
-		if ( null !== ( $dbuser = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dbuser' ) ) ) {
+		$dbuser     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dbuser' );
+		if ( null !== $dbuser ) {
 			$mysql_args['dbuser'] = $dbuser;
 		}
-		if ( null !== ( $dbpass = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dbpass' ) ) ) {
+		$dbpass = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dbpass' );
+		if ( null !== $dbpass ) {
 			$mysql_args['dbpass'] = $dbpass;
 		}
 		return $mysql_args;
@@ -1426,7 +1433,9 @@ class DB_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$table_sql       = self::esc_sql_ident( $table );
-		$primary_keys    = $text_columns = $all_columns = array();
+		$primary_keys    = array();
+		$text_columns    = array();
+		$all_columns     = array();
 		$suppress_errors = $wpdb->suppress_errors();
 		if ( ( $results = $wpdb->get_results( "DESCRIBE $table_sql" ) ) ) {
 			foreach ( $results as $col ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1090,7 +1090,7 @@ class DB_Command extends WP_CLI_Command {
 		$after_context = \WP_CLI\Utils\get_flag_value( $assoc_args, 'after_context', 40 );
 		$after_context = '' === $after_context ? $after_context : (int) $after_context;
 
-		$regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false )
+		$regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false );
 		if ( false !== $regex ) {
 			$regex_flags             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
 			$default_regex_delimiter = false;

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -865,7 +865,7 @@ class DB_Command extends WP_CLI_Command {
 					// Display the database size as a number.
 				switch ( $size_format ) {
 					case 'TB':
-							$divisor = pow( 1000, 4 );
+						$divisor = pow( 1000, 4 );
 						break;
 
 					case 'GB':

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -839,7 +839,6 @@ class DB_Command extends WP_CLI_Command {
 
 		if ( ! empty( $size_format ) || $human_readable ) {
 			foreach ( $rows as $index => $row ) {
-					// These added WP 4.4.0.
 				// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 				if ( ! defined( 'KB_IN_BYTES' ) ) {
 					define( 'KB_IN_BYTES', 1024 );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1342,7 +1342,7 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI\Utils\wp_get_table_names( array( $args[0] ), array() );
 
 		$columns = $wpdb->get_results(
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Asserted to be a valid table name through wp_get_table_names.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Asserted to be a valid table name through wp_get_table_names.
 			'SHOW COLUMNS FROM ' . $args[0]
 		);
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1425,7 +1425,9 @@ class DB_Command extends WP_CLI_Command {
 		$text_columns    = array();
 		$all_columns     = array();
 		$suppress_errors = $wpdb->suppress_errors();
-		if ( ( $results = $wpdb->get_results( "DESCRIBE $table_sql" ) ) ) {
+
+		$results = $wpdb->get_results( "DESCRIBE $table_sql" );
+		if ( $results ) {
 			foreach ( $results as $col ) {
 				if ( 'PRI' === $col->Key ) {
 					$primary_keys[] = $col->Field;

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1209,7 +1209,7 @@ class DB_Command extends WP_CLI_Command {
 								$offset          = $matches[0][ $i ][1];
 								$log             = $colors['match'][0] . $match . $colors['match'][1];
 								$before          = '';
-								after            = '';
+								$after           = '';
 								$after_shortened = false;
 
 								// Offsets are in bytes, so need to use `strlen()` and `substr()` before using `safe_substr()`.

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -465,7 +465,8 @@ class DB_Command extends WP_CLI_Command {
 		if ( ! empty( $args[0] ) ) {
 			$result_file = $args[0];
 		} else {
-			$hash        = substr( md5( wp_rand() ), 0, 7 );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand -- WordPress is not loaded.
+			$hash        = substr( md5( mt_rand() ), 0, 7 );
 			$result_file = sprintf( '%s-%s-%s.sql', DB_NAME, date( 'Y-m-d' ), $hash );
 
 		}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -886,7 +886,7 @@ class DB_Command extends WP_CLI_Command {
 
 					case 'gb':
 					case 'GiB':
-							$divisor = GB_IN_BYTES;
+						$divisor = GB_IN_BYTES;
 						break;
 
 					case 'mb':

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -868,7 +868,7 @@ class DB_Command extends WP_CLI_Command {
 						break;
 
 					case 'GB':
-							$divisor = pow( 1000, 3 );
+						$divisor = pow( 1000, 3 );
 						break;
 
 					case 'MB':

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1343,7 +1343,7 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI\Utils\wp_get_table_names( array( $args[0] ), array() );
 
 		$columns = $wpdb->get_results(
-		
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Asserted to be a valid table name through wp_get_table_names.
 			'SHOW COLUMNS FROM ' . $args[0]
 		);
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -872,7 +872,7 @@ class DB_Command extends WP_CLI_Command {
 						break;
 
 					case 'MB':
-							$divisor = pow( 1000, 2 );
+						$divisor = pow( 1000, 2 );
 						break;
 
 					case 'KB':

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -51,7 +51,7 @@ class DB_Command extends WP_CLI_Command {
 
 		self::run_query( self::get_create_query(), self::get_dbuser_dbpass_args( $assoc_args ) );
 
-		WP_CLI::success( "Database created." );
+		WP_CLI::success( 'Database created.' );
 	}
 
 	/**
@@ -82,7 +82,7 @@ class DB_Command extends WP_CLI_Command {
 
 		self::run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ), self::get_dbuser_dbpass_args( $assoc_args ) );
 
-		WP_CLI::success( "Database dropped." );
+		WP_CLI::success( 'Database dropped.' );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class DB_Command extends WP_CLI_Command {
 		self::run_query( sprintf( 'DROP DATABASE IF EXISTS `%s`', DB_NAME ), $mysql_args );
 		self::run_query( self::get_create_query(), $mysql_args );
 
-		WP_CLI::success( "Database reset." );
+		WP_CLI::success( 'Database reset.' );
 	}
 
 	/**
@@ -204,11 +204,17 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database checked.
 	 */
 	public function check( $_, $assoc_args ) {
-		self::run( Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ), array_merge( $assoc_args, array(
-			'check' => true,
-		) ) );
+		self::run(
+			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			array_merge(
+				$assoc_args,
+				array(
+					'check' => true,
+				)
+			)
+		);
 
-		WP_CLI::success( "Database checked." );
+		WP_CLI::success( 'Database checked.' );
 	}
 
 	/**
@@ -238,11 +244,17 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database optimized.
 	 */
 	public function optimize( $_, $assoc_args ) {
-		self::run( Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ), array_merge( $assoc_args, array(
-			'optimize' => true,
-		) ) );
+		self::run(
+			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			array_merge(
+				$assoc_args,
+				array(
+					'optimize' => true,
+				)
+			)
+		);
 
-		WP_CLI::success( "Database optimized." );
+		WP_CLI::success( 'Database optimized.' );
 	}
 
 	/**
@@ -272,11 +284,17 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database repaired.
 	 */
 	public function repair( $_, $assoc_args ) {
-		self::run( Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ), array_merge( $assoc_args, array(
-			'repair' => true,
-		) ) );
+		self::run(
+			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			array_merge(
+				$assoc_args,
+				array(
+					'repair' => true,
+				)
+			)
+		);
 
-		WP_CLI::success( "Database repaired." );
+		WP_CLI::success( 'Database repaired.' );
 	}
 
 	/**
@@ -369,7 +387,7 @@ class DB_Command extends WP_CLI_Command {
 		$assoc_args['database'] = DB_NAME;
 
 		// The query might come from STDIN
-		if ( !empty( $args ) ) {
+		if ( ! empty( $args ) ) {
 			$assoc_args['execute'] = $args[0];
 		}
 
@@ -450,7 +468,7 @@ class DB_Command extends WP_CLI_Command {
 	 *     --
 	 *     -- Host: localhost    Database: wpdev
 	 *     -- ------------------------------------------------------
-	 *     -- Server version	5.7.19
+	 *     -- Server version    5.7.19
 	 *     ...
 	 *
 	 * @alias dump
@@ -459,10 +477,11 @@ class DB_Command extends WP_CLI_Command {
 		if ( ! empty( $args[0] ) ) {
 			$result_file = $args[0];
 		} else {
-			$hash = substr( md5( mt_rand() ), 0, 7 );
-			$result_file = sprintf( '%s-%s-%s.sql', DB_NAME, date( 'Y-m-d' ), $hash );;
+			$hash        = substr( md5( mt_rand() ), 0, 7 );
+			$result_file = sprintf( '%s-%s-%s.sql', DB_NAME, date( 'Y-m-d' ), $hash );
+
 		}
-		$stdout = ( '-' === $result_file );
+		$stdout    = ( '-' === $result_file );
 		$porcelain = \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' );
 
 		// Bail if both porcelain and STDOUT are set.
@@ -489,7 +508,7 @@ class DB_Command extends WP_CLI_Command {
 			unset( $assoc_args['tables'] );
 			$command .= ' --tables';
 			foreach ( $tables as $table ) {
-				$command .= ' %s';
+				$command           .= ' %s';
 				$command_esc_args[] = trim( $table );
 			}
 		}
@@ -499,8 +518,8 @@ class DB_Command extends WP_CLI_Command {
 			$tables = explode( ',', trim( $assoc_args['exclude_tables'], ',' ) );
 			unset( $assoc_args['exclude_tables'] );
 			foreach ( $tables as $table ) {
-				$command .= ' --ignore-table';
-				$command .= ' %s';
+				$command           .= ' --ignore-table';
+				$command           .= ' %s';
 				$command_esc_args[] = trim( DB_NAME . '.' . $table );
 			}
 		}
@@ -514,8 +533,7 @@ class DB_Command extends WP_CLI_Command {
 
 		if ( $porcelain ) {
 			WP_CLI::line( $result_file );
-		}
-		else if ( ! $stdout ) {
+		} elseif ( ! $stdout ) {
 			WP_CLI::success( sprintf( "Exported to '%s'.", $result_file ) );
 		}
 	}
@@ -767,16 +785,16 @@ class DB_Command extends WP_CLI_Command {
 
 		global $wpdb;
 
-		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
-		$size_format = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
-		$human_readable = WP_CLI\Utils\get_flag_value( $assoc_args, 'human-readable', false );
-		$tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
-		$tables = ! empty( $tables );
-		$all_tables = WP_CLI\Utils\get_flag_value( $assoc_args, 'all-tables' );
+		$format                 = WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
+		$size_format            = WP_CLI\Utils\get_flag_value( $assoc_args, 'size_format' );
+		$human_readable         = WP_CLI\Utils\get_flag_value( $assoc_args, 'human-readable', false );
+		$tables                 = WP_CLI\Utils\get_flag_value( $assoc_args, 'tables' );
+		$tables                 = ! empty( $tables );
+		$all_tables             = WP_CLI\Utils\get_flag_value( $assoc_args, 'all-tables' );
 		$all_tables_with_prefix = WP_CLI\Utils\get_flag_value( $assoc_args, 'all-tables-with-prefix' );
 
-		if( ! is_null( $size_format ) && $human_readable ) {
-			WP_CLI::error( "Cannot use --size_format and --human-readable arguments at the same time." );
+		if ( ! is_null( $size_format ) && $human_readable ) {
+			WP_CLI::error( 'Cannot use --size_format and --human-readable arguments at the same time.' );
 		}
 
 		unset( $assoc_args['format'] );
@@ -789,7 +807,7 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		// Build rows for the formatter.
-		$rows = array();
+		$rows   = array();
 		$fields = array( 'Name', 'Size' );
 
 		$default_unit = ( empty( $size_format ) && ! $human_readable ) ? ' B' : '';
@@ -797,112 +815,114 @@ class DB_Command extends WP_CLI_Command {
 		if ( $tables || $all_tables || $all_tables_with_prefix ) {
 
 			// Add all of the table sizes
-			foreach( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
+			foreach ( WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) as $table_name ) {
 
 				// Get the table size.
-				$table_bytes = $wpdb->get_var( $wpdb->prepare(
-					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
-					DB_NAME,
-					$table_name
+				$table_bytes = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' and Table_Name = '%s' GROUP BY Table_Name LIMIT 1",
+						DB_NAME,
+						$table_name
 					)
 				);
 
 				// Add the table size to the list.
 				$rows[] = array(
-					'Name'  => $table_name,
-					'Size'  => strtoupper( $table_bytes ) . $default_unit,
+					'Name' => $table_name,
+					'Size' => strtoupper( $table_bytes ) . $default_unit,
 				);
 			}
 		} else {
 
 			// Get the database size.
-			$db_bytes = $wpdb->get_var( $wpdb->prepare(
-				"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
-				DB_NAME
+			$db_bytes = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT SUM(data_length + index_length) FROM information_schema.TABLES where table_schema = '%s' GROUP BY table_schema;",
+					DB_NAME
 				)
 			);
 
 			// Add the database size to the list.
 			$rows[] = array(
-				'Name'  => DB_NAME,
-				'Size'  => strtoupper( $db_bytes ) . $default_unit,
-				);
+				'Name' => DB_NAME,
+				'Size' => strtoupper( $db_bytes ) . $default_unit,
+			);
 		}
 
 		if ( ! empty( $size_format ) || $human_readable ) {
-			foreach( $rows as $index => $row ) {
+			foreach ( $rows as $index => $row ) {
 					// These added WP 4.4.0.
-					if ( ! defined( 'KB_IN_BYTES' ) ) {
-						define( 'KB_IN_BYTES', 1024 );
-					}
-					if ( ! defined( 'MB_IN_BYTES' ) ) {
-						define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
-					}
-				        if ( ! defined( 'GB_IN_BYTES' ) ) {
-						define( 'GB_IN_BYTES', 1024 * MB_IN_BYTES );
-					}
-				        if ( ! defined( 'TB_IN_BYTES' ) ) {
-						define( 'TB_IN_BYTES', 1024 * GB_IN_BYTES );
-					}
+				if ( ! defined( 'KB_IN_BYTES' ) ) {
+					define( 'KB_IN_BYTES', 1024 );
+				}
+				if ( ! defined( 'MB_IN_BYTES' ) ) {
+					define( 'MB_IN_BYTES', 1024 * KB_IN_BYTES );
+				}
+				if ( ! defined( 'GB_IN_BYTES' ) ) {
+					define( 'GB_IN_BYTES', 1024 * MB_IN_BYTES );
+				}
+				if ( ! defined( 'TB_IN_BYTES' ) ) {
+					define( 'TB_IN_BYTES', 1024 * GB_IN_BYTES );
+				}
 
-					if ( $human_readable ) {
-						$size_key = floor( log( $row['Size'] ) / log( 1000 ) );
-					    $sizes = array( 'B', 'KB', 'MB', 'GB', 'TB' );
+				if ( $human_readable ) {
+					$size_key = floor( log( $row['Size'] ) / log( 1000 ) );
+					$sizes    = array( 'B', 'KB', 'MB', 'GB', 'TB' );
 
-						$size_format = isset( $sizes[ $size_key ] ) ? $sizes[ $size_key ] : $sizes[ 0 ];
-					}
+					$size_format = isset( $sizes[ $size_key ] ) ? $sizes[ $size_key ] : $sizes[0];
+				}
 
 					// Display the database size as a number.
-					switch( $size_format ) {
-						case 'TB':
-						         $divisor = pow( 1000, 4 );
-							 break;
+				switch ( $size_format ) {
+					case 'TB':
+							 $divisor = pow( 1000, 4 );
+						break;
 
-						case 'GB':
-						         $divisor = pow( 1000, 3 );
-							 break;
+					case 'GB':
+							 $divisor = pow( 1000, 3 );
+						break;
 
-						case 'MB':
-						         $divisor = pow( 1000, 2 );
-							 break;
+					case 'MB':
+							 $divisor = pow( 1000, 2 );
+						break;
 
-						case 'KB':
-						         $divisor = 1000;
-							 break;
+					case 'KB':
+							 $divisor = 1000;
+						break;
 
-						case 'tb':
-						case 'TiB':
-						         $divisor = TB_IN_BYTES;
-							 break;
+					case 'tb':
+					case 'TiB':
+							 $divisor = TB_IN_BYTES;
+						break;
 
-						case 'gb':
-						case 'GiB':
-						         $divisor = GB_IN_BYTES;
-							 break;
+					case 'gb':
+					case 'GiB':
+							 $divisor = GB_IN_BYTES;
+						break;
 
-						case 'mb':
-						case 'MiB':
-							$divisor = MB_IN_BYTES;
-							break;
+					case 'mb':
+					case 'MiB':
+						$divisor = MB_IN_BYTES;
+						break;
 
-						case 'kb':
-						case 'KiB':
-							$divisor = KB_IN_BYTES;
-							break;
+					case 'kb':
+					case 'KiB':
+						$divisor = KB_IN_BYTES;
+						break;
 
-						case 'b':
-						case 'B':
-						default:
-							$divisor = 1;
-							break;
-					}
+					case 'b':
+					case 'B':
+					default:
+						$divisor = 1;
+						break;
+				}
 					$size_format_display = preg_replace( '/IB$/u', 'iB', strtoupper( $size_format ) );
 
-					$rows[ $index ]['Size'] = ceil( $row['Size'] / $divisor ) . " " . $size_format_display;
+					$rows[ $index ]['Size'] = ceil( $row['Size'] / $divisor ) . ' ' . $size_format_display;
 			}
 		}
 
-		if ( ! empty( $size_format) && ! $tables && ! $format && ! $human_readable && true !== $all_tables && true !== $all_tables_with_prefix ) {
+		if ( ! empty( $size_format ) && ! $tables && ! $format && ! $human_readable && true !== $all_tables && true !== $all_tables_with_prefix ) {
 			WP_CLI::Line( filter_var( $rows[0]['Size'], FILTER_SANITIZE_NUMBER_INT ) );
 		} else {
 			// Display the rows.
@@ -1083,24 +1103,31 @@ class DB_Command extends WP_CLI_Command {
 		$after_context = '' === $after_context ? $after_context : (int) $after_context;
 
 		if ( ( $regex = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex', false ) ) ) {
-			$regex_flags = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
+			$regex_flags             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags', false );
 			$default_regex_delimiter = false;
-			$regex_delimiter = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '' );
+			$regex_delimiter         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '' );
 			if ( '' === $regex_delimiter ) {
-				$regex_delimiter = chr( 1 );
+				$regex_delimiter         = chr( 1 );
 				$default_regex_delimiter = true;
 			}
 		}
 
-		$colors = self::get_colors( $assoc_args, array( 'table_column' => '%G', 'id' => '%Y', 'match' => $before_context || $after_context ? '%3%k' : '' ) );
+		$colors = self::get_colors(
+			$assoc_args,
+			array(
+				'table_column' => '%G',
+				'id'           => '%Y',
+				'match'        => $before_context || $after_context ? '%3%k' : '',
+			)
+		);
 
 		$table_column_once = \WP_CLI\Utils\get_flag_value( $assoc_args, 'table_column_once', false );
-		$one_line = \WP_CLI\Utils\get_flag_value( $assoc_args, 'one_line', false );
-		$matches_only = \WP_CLI\Utils\get_flag_value( $assoc_args, 'matches_only', false );
-		$stats = \WP_CLI\Utils\get_flag_value( $assoc_args, 'stats', false );
+		$one_line          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'one_line', false );
+		$matches_only      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'matches_only', false );
+		$stats             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'stats', false );
 
 		$column_count = $row_count = $match_count = 0;
-		$skipped = array();
+		$skipped      = array();
 
 		if ( $regex ) {
 			// Note the user must escape the delimiter in the search.
@@ -1110,15 +1137,15 @@ class DB_Command extends WP_CLI_Command {
 			}
 			if ( false === @preg_match( $search_regex, '' ) ) {
 				if ( $default_regex_delimiter ) {
-					$flags_msg = $regex_flags ? "flags '$regex_flags'" : "no flags";
-					$msg = "The regex pattern '$search' with default delimiter 'chr(1)' and {$flags_msg} fails.";
+					$flags_msg = $regex_flags ? "flags '$regex_flags'" : 'no flags';
+					$msg       = "The regex pattern '$search' with default delimiter 'chr(1)' and {$flags_msg} fails.";
 				} else {
 					$msg = "The regex '$search_regex' fails.";
 				}
 				WP_CLI::error( $msg );
 			}
 		} else {
-			$search_regex = '#' . preg_quote( $search, '#' ) . '#i';
+			$search_regex    = '#' . preg_quote( $search, '#' ) . '#i';
 			$esc_like_search = '%' . Utils\esc_like( $search ) . '%';
 		}
 
@@ -1147,13 +1174,13 @@ class DB_Command extends WP_CLI_Command {
 				}
 				continue;
 			}
-			$table_sql = self::esc_sql_ident( $table );
+			$table_sql     = self::esc_sql_ident( $table );
 			$column_count += count( $text_columns );
 			if ( ! $primary_keys ) {
 				WP_CLI::warning( "No primary key for table '$table'. No row ids will be outputted." );
 				$primary_key = $primary_key_sql = '';
 			} else {
-				$primary_key = array_shift( $primary_keys );
+				$primary_key     = array_shift( $primary_keys );
 				$primary_key_sql = self::esc_sql_ident( $primary_key ) . ', ';
 			}
 
@@ -1165,8 +1192,8 @@ class DB_Command extends WP_CLI_Command {
 					$results = $wpdb->get_results( $wpdb->prepare( "SELECT {$primary_key_sql}{$column_sql} FROM {$table_sql} WHERE {$column_sql} LIKE %s;", $esc_like_search ) );
 				}
 				if ( $results ) {
-					$row_count += count( $results );
-					$table_column_val = $colors['table_column'][0] . "{$table}:{$column}" . $colors['table_column'][1];
+					$row_count                  += count( $results );
+					$table_column_val            = $colors['table_column'][0] . "{$table}:{$column}" . $colors['table_column'][1];
 					$outputted_table_column_once = false;
 					foreach ( $results as $result ) {
 						$col_val = $result->$column;
@@ -1177,19 +1204,19 @@ class DB_Command extends WP_CLI_Command {
 							}
 							$pk_val = $primary_key ? ( $colors['id'][0] . $result->$primary_key . $colors['id'][1] . ':' ) : '';
 
-							$bits = array();
+							$bits         = array();
 							$col_encoding = $encoding;
 							if ( ! $col_encoding && ( $before_context || $after_context ) && function_exists( 'mb_detect_encoding' ) ) {
 								$col_encoding = mb_detect_encoding( $col_val, null, true /*strict*/ );
 							}
 							$append_next = false;
 							$last_offset = 0;
-							$match_cnt = count( $matches[0] );
+							$match_cnt   = count( $matches[0] );
 							for ( $i = 0; $i < $match_cnt; $i++ ) {
-								$match = $matches[0][ $i ][0];
-								$offset = $matches[0][ $i ][1];
-								$log = $colors['match'][0] . $match . $colors['match'][1];
-								$before = $after = '';
+								$match           = $matches[0][ $i ][0];
+								$offset          = $matches[0][ $i ][1];
+								$log             = $colors['match'][0] . $match . $colors['match'][1];
+								$before          = $after = '';
 								$after_shortened = false;
 
 								// Offsets are in bytes, so need to use `strlen()` and `substr()` before using `safe_substr()`.
@@ -1198,16 +1225,16 @@ class DB_Command extends WP_CLI_Command {
 								}
 								if ( $after_context ) {
 									$end_offset = $offset + strlen( $match );
-									$after = \cli\safe_substr( substr( $col_val, $end_offset ), 0, $after_context, false /*is_width*/, $col_encoding );
+									$after      = \cli\safe_substr( substr( $col_val, $end_offset ), 0, $after_context, false /*is_width*/, $col_encoding );
 									// To lessen context duplication in output, shorten the after context if it overlaps with the next match.
 									if ( $i + 1 < $match_cnt && $end_offset + strlen( $after ) > $matches[0][ $i + 1 ][1] ) {
-										$after = substr( $after, 0, $matches[0][ $i + 1 ][1] - $end_offset );
+										$after           = substr( $after, 0, $matches[0][ $i + 1 ][1] - $end_offset );
 										$after_shortened = true;
 										// On the next iteration, will append with no before context.
 									}
 								}
 								if ( $append_next ) {
-									$cnt = count( $bits );
+									$cnt               = count( $bits );
 									$bits[ $cnt - 1 ] .= $log . $after;
 								} else {
 									$bits[] = $before . $log . $after;
@@ -1216,7 +1243,7 @@ class DB_Command extends WP_CLI_Command {
 								$last_offset = $offset;
 							}
 							$match_count += $match_cnt;
-							$col_val = implode( ' [...] ', $bits );
+							$col_val      = implode( ' [...] ', $bits );
 
 							WP_CLI::log( $matches_only ? $col_val : ( $one_line ? "{$table_column_val}:{$pk_val}{$col_val}" : "{$pk_val}{$col_val}" ) );
 						}
@@ -1226,22 +1253,33 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		if ( $stats ) {
-			$table_count = count( $tables );
+			$table_count   = count( $tables );
 			$skipped_count = count( $skipped );
-			$match_str = 1 === $match_count ? 'match' : 'matches';
-			$table_str = 1 === $table_count ? 'table' : 'tables';
-			$column_str = 1 === $column_count ? 'column' : 'columns';
-			$row_str = 1 === $row_count ? 'row' : 'rows';
-			$skipped_str = 1 === $skipped_count ? 'table skipped' : 'tables skipped';
+			$match_str     = 1 === $match_count ? 'match' : 'matches';
+			$table_str     = 1 === $table_count ? 'table' : 'tables';
+			$column_str    = 1 === $column_count ? 'column' : 'columns';
+			$row_str       = 1 === $row_count ? 'row' : 'rows';
+			$skipped_str   = 1 === $skipped_count ? 'table skipped' : 'tables skipped';
 			if ( 0 !== $skipped_count ) {
 				$skipped_str .= ': ' . implode( ', ', $skipped );
 			}
-			$end_time = microtime( true );
-			$run_time = $end_time - $start_run_time;
+			$end_time    = microtime( true );
+			$run_time    = $end_time - $start_run_time;
 			$search_time = $end_time - $start_search_time;
-			$stats_msg = sprintf(
-				"Found %d %s in %.3fs (%.3fs searching). Searched %d %s, %d %s, %d %s. %d %s.",
-				$match_count, $match_str, $run_time, $search_time, $table_count, $table_str, $column_count, $column_str, $row_count, $row_str, $skipped_count, $skipped_str
+			$stats_msg   = sprintf(
+				'Found %d %s in %.3fs (%.3fs searching). Searched %d %s, %d %s, %d %s. %d %s.',
+				$match_count,
+				$match_str,
+				$run_time,
+				$search_time,
+				$table_count,
+				$table_str,
+				$column_count,
+				$column_str,
+				$row_count,
+				$row_str,
+				$skipped_count,
+				$skipped_str
 			);
 			WP_ClI::success( $stats_msg );
 		}
@@ -1387,8 +1425,8 @@ class DB_Command extends WP_CLI_Command {
 	private static function get_columns( $table ) {
 		global $wpdb;
 
-		$table_sql = self::esc_sql_ident( $table );
-		$primary_keys = $text_columns = $all_columns = array();
+		$table_sql       = self::esc_sql_ident( $table );
+		$primary_keys    = $text_columns = $all_columns = array();
 		$suppress_errors = $wpdb->suppress_errors();
 		if ( ( $results = $wpdb->get_results( "DESCRIBE $table_sql" ) ) ) {
 			foreach ( $results as $col ) {
@@ -1413,8 +1451,9 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	private static function is_text_col( $type ) {
 		foreach ( array( 'text', 'varchar' ) as $token ) {
-			if ( false !== strpos( $type, $token ) )
+			if ( false !== strpos( $type, $token ) ) {
 				return true;
+			}
 		}
 
 		return false;
@@ -1448,9 +1487,15 @@ class DB_Command extends WP_CLI_Command {
 	private function get_colors( $assoc_args, $colors ) {
 		$color_reset = WP_CLI::colorize( '%n' );
 
-		$color_codes = implode( '', array_map( function ( $v ) {
-			return substr( $v, 1 );
-		}, array_keys( \cli\Colors::getColors() ) ) );
+		$color_codes = implode(
+			'',
+			array_map(
+				function ( $v ) {
+					return substr( $v, 1 );
+				},
+				array_keys( \cli\Colors::getColors() )
+			)
+		);
 
 		$color_codes_regex = '/^(?:%[' . $color_codes . '])*$/';
 
@@ -1562,15 +1607,15 @@ class DB_Command extends WP_CLI_Command {
 			'version',
 			'vertical',
 			'wait',
-			'xml'
+			'xml',
 		];
 
 		$mysql_args = array();
 
 		foreach ( $assoc_args as $mysql_option_key => $mysql_option_value ) {
 			// Check flags to make sure they only contain valid options.
-			if ( in_array( $mysql_option_key,  $allowed_mysql_options, true ) && ! empty( $mysql_option_value ) ) {
-				$mysql_args[$mysql_option_key] = $mysql_option_value;
+			if ( in_array( $mysql_option_key, $allowed_mysql_options, true ) && ! empty( $mysql_option_value ) ) {
+				$mysql_args[ $mysql_option_key ] = $mysql_option_value;
 			}
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1117,7 +1117,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$column_count = 0;
 		$row_count    = 0;
-		$match_count  = 0
+		$match_count  = 0;
 		$skipped      = array();
 
 		if ( $regex ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1432,7 +1432,7 @@ class DB_Command extends WP_CLI_Command {
 		$all_columns     = array();
 		$suppress_errors = $wpdb->suppress_errors();
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Asserted to be a valid table name through wp_get_table_names.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Escaped through esc_sql_ident/esc_like.
 		$results = $wpdb->get_results( "DESCRIBE $table_sql" );
 		if ( $results ) {
 			foreach ( $results as $col ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -881,7 +881,7 @@ class DB_Command extends WP_CLI_Command {
 
 					case 'tb':
 					case 'TiB':
-							$divisor = TB_IN_BYTES;
+						$divisor = TB_IN_BYTES;
 						break;
 
 					case 'gb':


### PR DESCRIPTION
Add a PHPCS ruleset using the new WP_CLI_CS standard.

Fixes https://github.com/wp-cli/db-command/issues/139

Related wp-cli/wp-cli#5179