### PR TITLE
Make wp db clean get all the tables with prefix

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -160,8 +160,9 @@ class DB_Command extends WP_CLI_Command {
 
 		$tables = Utils\wp_get_table_names(
 			array(),
-			array( 'all-tables-with-prefix' )
+			array( 'all-tables-with-prefix' => true )
 		);
+
 
 		foreach ( $tables as $table ) {
 			self::run_query(

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -163,7 +163,6 @@ class DB_Command extends WP_CLI_Command {
 			array( 'all-tables-with-prefix' => true )
 		);
 
-
 		foreach ( $tables as $table ) {
 			self::run_query(
 				sprintf(


### PR DESCRIPTION
This PR fixes the issue where `wp db clean` was not dropping tables that use the same database prefix, but weren't in the WordPress schema.

Fixes #150 