### PR TITLE
Bump Travis CI OS from `trusty` to `xenial`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 os: linux
-dist: trusty
+dist: xenial
 
 language: php
 php: 7.3
+
+services:
+  - mysql
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=3.7.11
+      dist: trusty
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -96,7 +96,7 @@ Feature: Query the database with WordPress' MySQL config
   Scenario: SQL modes do not include any of the modes incompatible with WordPress
     Given a WP install
 
-    When I run `wp db query 'SELECT @@SESSION.sql_mode;'`
+    When I try `wp db query 'SELECT @@SESSION.sql_mode;' --debug`
     Then STDOUT should not contain:
       """
       NO_ZERO_DATE

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -92,3 +92,32 @@ Feature: Query the database with WordPress' MySQL config
       """
       Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
       """
+
+  Scenario: SQL modes do not include any of the modes incompatible with WordPress
+    Given a WP install
+
+    When I run `wp db query 'SELECT @@SESSION.sql_mode;'`
+    Then STDOUT should not contain:
+      """
+      NO_ZERO_DATE
+      """
+    And STDOUT should not contain:
+      """
+      ONLY_FULL_GROUP_BY
+      """
+    And STDOUT should not contain:
+      """
+      STRICT_TRANS_TABLES
+      """
+    And STDOUT should not contain:
+      """
+      STRICT_ALL_TABLES
+      """
+    And STDOUT should not contain:
+      """
+      TRADITIONAL
+      """
+    And STDOUT should not contain:
+      """
+      ANSI
+      """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -227,6 +227,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['check'] = true;
 		self::run(
@@ -270,6 +271,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['optimize'] = true;
 		self::run(
@@ -313,6 +315,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['repair'] = true;
 		self::run(
@@ -354,10 +357,11 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * @alias connect
 	 */
-	public function cli( $args, $assoc_args ) {
+	public function cli( $_, $assoc_args ) {
 
 		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		if ( ! isset( $assoc_args['database'] ) ) {
 			$assoc_args['database'] = DB_NAME;
@@ -423,6 +427,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['database'] = DB_NAME;
 
@@ -558,6 +563,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running initial shell command: {$initial_command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		if ( $support_column_statistics ) {
 			$command = $initial_command . '--skip-column-statistics %s';
@@ -666,6 +672,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		self::run( $command, $mysql_args );
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -430,18 +430,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$assoc_args['database'] = DB_NAME;
 
-		if (
-			! isset( $assoc_args['result-format'] )
-			&& ! isset( $assoc_args['table'] )
-			&& ! isset( $assoc_args['tabbed'] )
-			&& ! isset( $assoc_args['vertical'] )
-			&& ! isset( $assoc_args['json'] )
-			&& ! isset( $assoc_args['html'] )
-			&& ! isset( $assoc_args['silent'] )
-		) {
-			$assoc_args['table'] = true;
-		}
-
 		// The query might come from STDIN.
 		if ( ! empty( $args ) ) {
 			$assoc_args['execute'] = $args[0];

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -426,6 +426,18 @@ class DB_Command extends WP_CLI_Command {
 
 		$assoc_args['database'] = DB_NAME;
 
+		if (
+			! isset( $assoc_args['result-format'] )
+			&& ! isset( $assoc_args['table'] )
+			&& ! isset( $assoc_args['tabbed'] )
+			&& ! isset( $assoc_args['vertical'] )
+			&& ! isset( $assoc_args['json'] )
+			&& ! isset( $assoc_args['html'] )
+			&& ! isset( $assoc_args['silent'] )
+		) {
+			$assoc_args['table'] = true;
+		}
+
 		// The query might come from STDIN.
 		if ( ! empty( $args ) ) {
 			$assoc_args['execute'] = $args[0];
@@ -1811,7 +1823,16 @@ class DB_Command extends WP_CLI_Command {
 
 		// Make sure the provided arguments don't interfere with the expected
 		// output here.
-		unset( $assoc_args['column-names'], $assoc_args['html'] );
+		$args = $assoc_args;
+		unset(
+			$args['column-names'],
+			$args['result-format'],
+			$args['json'],
+			$args['html'],
+			$args['table'],
+			$args['tabbed'],
+			$args['vertical'],
+		);
 
 		if ( null === $modes ) {
 			$modes = [];
@@ -1821,7 +1842,7 @@ class DB_Command extends WP_CLI_Command {
 					'/usr/bin/env mysql%s --no-auto-rehash --batch --skip-column-names',
 					$this->get_defaults_flag_string( $assoc_args )
 				),
-				array_merge( $assoc_args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),
+				array_merge( $args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),
 				false
 			);
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1825,8 +1825,8 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI::debug(
 			sprintf(
 				'SQL mode adaptation is needed: %s => %s',
-				$this->get_current_sql_modes( $assoc_args ),
-				$modes
+				json_encode( $this->get_current_sql_modes( $assoc_args ) ),
+				json_encode( $modes )
 			)
 		);
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1881,7 +1881,7 @@ class DB_Command extends WP_CLI_Command {
 				$modes = array_filter(
 					array_map(
 						'trim',
-						preg_split( "/\r\n|\n|\r/", $stdout )
+						preg_split( "/\r\n|\n|\r/|,", $stdout )
 					)
 				);
 			}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -227,7 +227,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['check'] = true;
 		self::run(
@@ -235,6 +234,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args
 		);
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database checked.' );
 	}
 
@@ -271,7 +271,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['optimize'] = true;
 		self::run(
@@ -279,6 +278,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args
 		);
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database optimized.' );
 	}
 
@@ -315,7 +315,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['repair'] = true;
 		self::run(
@@ -323,6 +322,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args
 		);
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database repaired.' );
 	}
 
@@ -361,12 +361,12 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		if ( ! isset( $assoc_args['database'] ) ) {
 			$assoc_args['database'] = DB_NAME;
 		}
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		self::run( $command, $assoc_args );
 	}
 
@@ -427,7 +427,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$assoc_args['database'] = DB_NAME;
 
@@ -453,6 +452,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $this->get_sql_mode_query( $assoc_args ) . $assoc_args['execute'];
 		}
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		self::run( $command, $assoc_args );
 	}
 
@@ -563,7 +563,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running initial shell command: {$initial_command}", 'db' );
-		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		if ( $support_column_statistics ) {
 			$command = $initial_command . '--skip-column-statistics %s';
@@ -599,6 +598,7 @@ class DB_Command extends WP_CLI_Command {
 		// Remove parameters not needed for SQL run.
 		unset( $assoc_args['porcelain'] );
 
+		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		self::run( $escaped_command, $assoc_args );
 
 		if ( $porcelain ) {
@@ -1003,7 +1003,7 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		if ( ! empty( $size_format ) && ! $tables && ! $format && ! $human_readable && true !== $all_tables && true !== $all_tables_with_prefix ) {
-			WP_CLI::Line( filter_var( $rows[0]['Size'], FILTER_SANITIZE_NUMBER_INT ) );
+			WP_CLI::line( filter_var( $rows[0]['Size'], FILTER_SANITIZE_NUMBER_INT ) );
 		} else {
 			// Display the rows.
 			$args = [
@@ -1470,6 +1470,8 @@ class DB_Command extends WP_CLI_Command {
 	protected function run_query( $query, $assoc_args = [] ) {
 		// Ensure that the SQL mode is compatible with WPDB.
 		$query = $this->get_sql_mode_query( $assoc_args ) . $query;
+
+		WP_CLI::debug( "Query: {$query}", 'db' );
 
 		self::run(
 			sprintf(

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1839,7 +1839,7 @@ class DB_Command extends WP_CLI_Command {
 			$args['html'],
 			$args['table'],
 			$args['tabbed'],
-			$args['vertical'],
+			$args['vertical']
 		);
 
 		if ( null === $modes ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1442,7 +1442,7 @@ class DB_Command extends WP_CLI_Command {
 	/**
 	 * Run a single query via the 'mysql' binary.
 	 *
-	 * This includes necessary setup to make sure the queries behave similar
+	 * This includes the necessary setup to make sure the queries behave similar
 	 * to what WPDB produces.
 	 *
 	 * @param string $query      Query to execute.
@@ -1783,10 +1783,16 @@ class DB_Command extends WP_CLI_Command {
 
 		$modes = array_change_key_case( $modes, CASE_UPPER );
 
+		$is_mode_adaptation_needed = false;
 		foreach ( $modes as $i => $mode ) {
 			if ( in_array( $mode, $this->sql_incompatible_modes, true ) ) {
 				unset( $modes[ $i ] );
+				$is_mode_adaptation_needed = true;
 			}
+		}
+
+		if ( ! $is_mode_adaptation_needed ) {
+			return '';
 		}
 
 		$modes_str = implode( ',', $modes );
@@ -1803,7 +1809,7 @@ class DB_Command extends WP_CLI_Command {
 	protected function get_current_sql_modes( $assoc_args ) {
 		static $modes = null;
 
-		// Make sure the provided argument don't interfere with the expected
+		// Make sure the provided arguments don't interfere with the expected
 		// output here.
 		unset( $assoc_args['column-names'], $assoc_args['html'] );
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1881,7 +1881,7 @@ class DB_Command extends WP_CLI_Command {
 				$modes = array_filter(
 					array_map(
 						'trim',
-						preg_split( "/\r\n|\n|\r/|,", $stdout )
+						preg_split( "/\r\n|\n|\r|,/", $stdout )
 					)
 				);
 			}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1813,6 +1813,12 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		if ( ! $is_mode_adaptation_needed ) {
+			WP_CLI::debug(
+				sprintf(
+					'SQL modes look fine: %s',
+					json_encode( $modes )
+				)
+			);
 			return '';
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1807,6 +1807,14 @@ class DB_Command extends WP_CLI_Command {
 			return '';
 		}
 
+		WP_CLI::debug(
+			sprintf(
+				'SQL mode adaptation is needed: %s => %s',
+				$this->get_current_sql_modes( $assoc_args ),
+				$modes
+			)
+		);
+
 		$modes_str = implode( ',', $modes );
 
 		return "SET SESSION sql_mode='{$modes_str}';";


### PR DESCRIPTION
This PR changes the Travis CI configuration to use the `xenial` Ubuntu distribution instead of the `trusty` one by default.

Also makes modifications to the code first started in #169 so that it actually works as expected.