### PR TITLE
Add SQL mode compat query to db import command

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1836,16 +1836,12 @@ class DB_Command extends WP_CLI_Command {
 
 		// Make sure the provided arguments don't interfere with the expected
 		// output here.
-		$args = $assoc_args;
-		unset(
-			$args['column-names'],
-			$args['result-format'],
-			$args['json'],
-			$args['html'],
-			$args['table'],
-			$args['tabbed'],
-			$args['vertical']
-		);
+		$args = [];
+		foreach ( [] as $arg ) {
+			if ( isset( $assoc_args[ $arg ] ) ) {
+				$args[ $arg ] = $assoc_args[ $arg ];
+			}
+		}
 
 		if ( null === $modes ) {
 			$modes = [];

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -651,6 +651,8 @@ class DB_Command extends WP_CLI_Command {
 				? 'SOURCE %s;'
 				: 'SET autocommit = 0; SET unique_checks = 0; SET foreign_key_checks = 0; SOURCE %s; COMMIT;';
 
+			$query = $this->get_sql_mode_query( $assoc_args ) . $query;
+
 			$mysql_args['execute'] = sprintf( $query, $result_file );
 		} else {
 			$result_file = 'STDIN';


### PR DESCRIPTION
This adds the SQL mode compat logic to the `*.sql` file that is being used to run `db import`.

However, this only works if an actual file is being loaded. It doesn't take into account the use case where we use `-` as the file and then pipe SQL code directly into `mysql`. Trying to cover this case as well might open up a whole new can of worms and should be handled separately. See #171 