### PR TITLE
Set `$interactive = true` when output is `STDOUT`

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -600,10 +600,10 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
 		$send_to_shell = true;
-		$interactive = false;
+		$interactive   = false;
 		if ( true === $stdout ) {
 			$send_to_shell = false;
-			$interactive = true;
+			$interactive   = true;
 		}
 
 		self::run( $escaped_command, $assoc_args, $send_to_shell, $interactive );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -598,7 +598,14 @@ class DB_Command extends WP_CLI_Command {
 		unset( $assoc_args['porcelain'] );
 
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
-		self::run( $escaped_command, $assoc_args );
+
+		$send_to_shell = true;
+		$interactive = false;
+		if ( true === $stdout ) {
+			$interactive = true;
+		}
+
+		self::run( $escaped_command, $assoc_args, $send_to_shell, $interactive );
 
 		if ( $porcelain ) {
 			WP_CLI::line( $result_file );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -602,6 +602,7 @@ class DB_Command extends WP_CLI_Command {
 		$send_to_shell = true;
 		$interactive = false;
 		if ( true === $stdout ) {
+			$send_to_shell = false;
 			$interactive = true;
 		}
 


### PR DESCRIPTION
Changes to [run_mysql_command](https://github.com/wp-cli/wp-cli/blob/c3bd5bd76abf024f9d492579539646e0d263a05a/php/utils.php#L502) made it load process output
into variables, which for `db export` tends to OOM and completely breaks piping.
The old behavior is retained when `$interactive = true`
for `run_mysql_command`. When we're outputting to STDOUT, interactive
mode makes sense as it defaults to `STDIN/STDOUT` which in my opinion
is the expected behavior.

Fixes https://github.com/wp-cli/db-command/issues/195
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
