### PR TITLE
Set `'utf8mb4'` when exporting without `'--default-character-set'` option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^3.0.11"
+        "wp-cli/wp-cli-tests": "^3.0.17"
     },
     "config": {
         "process-timeout": 7200,

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -151,6 +151,8 @@ Feature: Import a WordPress database
       """
       Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
       """
+
+  @require-wp-4.2
   Scenario: Import db that has emoji in post
     Given a WP install
 

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -157,14 +157,23 @@ Feature: Import a WordPress database
     Given a WP install
 
     When I run `wp post create --post_title="🍣"`
-    And I run `wp db export wp_cli_test.sql`
-    Then the wp_cli_test.sql file should exist
-
-    When I run `wp post list`
+    And I run `wp post list`
     Then the return code should be 0
     And STDOUT should contain:
       """
       🍣
+      """
+
+    When I try `wp db export wp_cli_test.sql --debug`
+    Then the return code should be 0
+    And the wp_cli_test.sql file should exist
+    And STDERR should contain:
+      """
+      Detected character set of the posts table: utf8mb4
+      """
+    And STDERR should contain:
+      """
+      Setting missing default character set to utf8mb4
       """
 
     When I run `wp db import --dbuser=wp_cli_test --dbpass=password1`

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -151,3 +151,29 @@ Feature: Import a WordPress database
       """
       Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
       """
+  Scenario: Import db that has emoji in post
+    Given a WP install
+
+    When I run `wp post create --post_title="🍣"`
+    And I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I run `wp post list`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      🍣
+      """
+
+    When I run `wp db import --dbuser=wp_cli_test --dbpass=password1`
+    Then STDOUT should be:
+      """
+      Success: Imported from 'wp_cli_test.sql'.
+      """
+
+    When I run `wp post list`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      🍣
+      """

--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -917,42 +917,42 @@ Feature: Search through the database
     Given a WP install
 
     When I run `SHELL_PIPE=0 wp db search example.com`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
       [33;1m1[0m:http://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --table_column_color=%r --id_color=%g --match_color=%b`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [31mwp_options:option_value[0m
       [32m1[0m:http://[34mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --table_column_color=%r`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [31mwp_options:option_value[0m
       [33;1m1[0m:http://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --id_color=%g`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
       [32m1[0m:http://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --match_color=%b`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
       [33;1m1[0m:http://[34mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --before_context=0 --after_context=0`
-    Then STDOUT should contain:
+    Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
       [33;1m1[0m:example.com
@@ -967,7 +967,7 @@ Feature: Search through the database
       """
       example.com
       """
-    And STDOUT should not contain:
+    And STDOUT should strictly not contain:
       """
       
       """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -28,6 +28,20 @@ use WP_CLI\Utils;
 class DB_Command extends WP_CLI_Command {
 
 	/**
+	 * Legacy UTF-8 encoding for MySQL.
+	 *
+	 * @var string
+	 */
+	const ENCODING_UTF8 = 'utf8';
+
+	/**
+	 * Standards-compliant UTF-8 encoding for MySQL.
+	 *
+	 * @var string
+	 */
+	const ENCODING_UTF8MB4 = 'utf8mb4';
+
+	/**
 	 * A list of incompatible SQL modes.
 	 *
 	 * Copied over from WordPress Core code.
@@ -556,11 +570,19 @@ class DB_Command extends WP_CLI_Command {
 
 		/*
 		 * In case that `--default-character-set` is not given and `DB_CHARSET` is `utf8`,
-		 * use `utf8mb4` as a `default-character-set` to ensure emojis are encoded correctly.
+		 * we try to deduce what the actual character set for the posts table of the
+		 * current database is and use `utf8mb4` as a `default-character-set` if that
+		 * seems like the safer default, to ensure emojis are encoded correctly.
 		 */
-		if ( ! isset( $assoc_args['default-character-set'] ) &&
-			defined( 'DB_CHARSET' ) && 'utf8' === constant( 'DB_CHARSET' ) ) {
-			$assoc_args['default-character-set'] = 'utf8mb4';
+		if (
+			! isset( $assoc_args['default-character-set'] )
+			&&
+			( defined( 'DB_CHARSET' ) && self::ENCODING_UTF8 === constant( 'DB_CHARSET' ) )
+			&&
+			self::ENCODING_UTF8MB4 === $this->get_posts_table_charset( $assoc_args )
+		) {
+			WP_CLI::debug( 'Setting missing default character set to ' . self::ENCODING_UTF8MB4, 'db' );
+			$assoc_args['default-character-set'] = self::ENCODING_UTF8MB4;
 		}
 
 		$initial_command = sprintf( "{$mysqldump_binary}%s ", $this->get_defaults_flag_string( $assoc_args ) );
@@ -614,6 +636,45 @@ class DB_Command extends WP_CLI_Command {
 		} elseif ( ! $stdout ) {
 			WP_CLI::success( sprintf( "Exported to '%s'.", $result_file ) );
 		}
+	}
+
+	/**
+	 * Get the current character set of the posts table.
+	 *
+	 * @param array Associative array of associative arguments.
+	 * @return string Posts table character set.
+	 */
+	private function get_posts_table_charset( $assoc_args ) {
+		$query = 'SELECT CCSA.character_set_name '
+				. 'FROM information_schema.`TABLES` T, '
+				. 'information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA '
+				. 'WHERE CCSA.collation_name = T.table_collation '
+				. 'AND T.table_schema = "' . DB_NAME . '" '
+				. 'AND T.table_name LIKE "%\_posts";';
+
+		list( $stdout, $stderr, $exit_code ) = self::run(
+			sprintf(
+				'/usr/bin/env mysql%s --no-auto-rehash --batch --skip-column-names',
+				$this->get_defaults_flag_string( $assoc_args )
+			),
+			[ 'execute' => $query ],
+			false
+		);
+
+		if ( $exit_code ) {
+			WP_CLI::warning(
+				'Failed to get current character set of the posts table.'
+				. ( ! empty( $stderr ) ? " Reason: {$stderr}" : '' )
+			);
+
+			return self::ENCODING_UTF8MB4;
+		}
+
+		$stdout = trim( $stdout );
+
+		WP_CLI::debug( "Detected character set of the posts table: {$stdout}.", 'db' );
+
+		return $stdout;
 	}
 
 	/**
@@ -1244,7 +1305,7 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		$encoding = null;
-		if ( 0 === strpos( $wpdb->charset, 'utf8' ) ) {
+		if ( 0 === strpos( $wpdb->charset, self::ENCODING_UTF8 ) ) {
 			$encoding = 'UTF-8';
 		}
 
@@ -1616,7 +1677,7 @@ class DB_Command extends WP_CLI_Command {
 	 * @return string|array An escaped string if given a string, or an array of escaped strings if given an array of strings.
 	 */
 	private static function esc_sql_ident( $idents ) {
-		$backtick = function ( $v ) {
+		$backtick = static function ( $v ) {
 			// Escape any backticks in the identifier by doubling.
 			return '`' . str_replace( '`', '``', $v ) . '`';
 		};

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -554,6 +554,16 @@ class DB_Command extends WP_CLI_Command {
 
 		$support_column_statistics = exec( $mysqldump_binary . ' --help | grep "column-statistics"' );
 
+		/**
+		 * Issue #144
+		 * In case that `--default-character-set` is not given and `DB_CHARSET` is `utf8`,
+		 * use `utf8mb4` as a default-character-set to show emoji.
+		 */
+		if ( !isset( $assoc_args['default-character-set'] ) &&
+			defined( 'DB_CHARSET' ) && 'utf8' == constant( 'DB_CHARSET' ) ) {
+			$assoc_args['default-character-set'] = 'utf8mb4';
+		}
+
 		$initial_command = sprintf( "{$mysqldump_binary}%s ", $this->get_defaults_flag_string( $assoc_args ) );
 		WP_CLI::debug( "Running initial shell command: {$initial_command}", 'db' );
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -559,7 +559,7 @@ class DB_Command extends WP_CLI_Command {
 		 * use `utf8mb4` as a `default-character-set` to ensure emojis are encoded correctly.
 		 */
 		if ( ! isset( $assoc_args['default-character-set'] ) &&
-			defined( 'DB_CHARSET' ) && 'utf8' == constant( 'DB_CHARSET' ) ) {
+			defined( 'DB_CHARSET' ) && 'utf8' === constant( 'DB_CHARSET' ) ) {
 			$assoc_args['default-character-set'] = 'utf8mb4';
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -554,10 +554,9 @@ class DB_Command extends WP_CLI_Command {
 
 		$support_column_statistics = exec( $mysqldump_binary . ' --help | grep "column-statistics"' );
 
-		/**
-		 * Issue #144
+		/*
 		 * In case that `--default-character-set` is not given and `DB_CHARSET` is `utf8`,
-		 * use `utf8mb4` as a default-character-set to show emoji.
+		 * use `utf8mb4` as a `default-character-set` to ensure emojis are encoded correctly.
 		 */
 		if ( !isset( $assoc_args['default-character-set'] ) &&
 			defined( 'DB_CHARSET' ) && 'utf8' == constant( 'DB_CHARSET' ) ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -558,7 +558,7 @@ class DB_Command extends WP_CLI_Command {
 		 * In case that `--default-character-set` is not given and `DB_CHARSET` is `utf8`,
 		 * use `utf8mb4` as a `default-character-set` to ensure emojis are encoded correctly.
 		 */
-		if ( !isset( $assoc_args['default-character-set'] ) &&
+		if ( ! isset( $assoc_args['default-character-set'] ) &&
 			defined( 'DB_CHARSET' ) && 'utf8' == constant( 'DB_CHARSET' ) ) {
 			$assoc_args['default-character-set'] = 'utf8mb4';
 		}


### PR DESCRIPTION
Fixes: #144 

I'm not sure whether this approach is correct.
Kindly check this PR in your time.
