### PR TITLE
To be succeeded behat test export database to STDOUT even if uses mariadb

### DIFF
--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -40,7 +40,7 @@ Feature: Export a WordPress database
     When I run `wp db export -`
     Then STDOUT should contain:
       """
-      -- MySQL dump
+      -- Dump completed on
       """
 
   Scenario: Export database with mysql defaults to STDOUT
@@ -49,7 +49,7 @@ Feature: Export a WordPress database
     When I run `wp db export --defaults -`
     Then STDOUT should contain:
       """
-      -- MySQL dump
+      -- Dump completed on
       """
 
   Scenario: Export database with mysql --no-defaults to STDOUT
@@ -58,7 +58,7 @@ Feature: Export a WordPress database
     When I run `wp db export --no-defaults -`
     Then STDOUT should contain:
       """
-      -- MySQL dump
+      -- Dump completed on
       """
 
   Scenario: Export database with passed-in options


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

related: #200 

Currently, mariaDB fails behat test in export database to STDOUT because it only checks whether it contains `-- MySQL dump`.
But both MySQL and mariaDB contain  `Dump completed on` in dump. 