### PR TITLE
Stop reordering most mysql arguments

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1620,7 +1620,7 @@ class DB_Command extends WP_CLI_Command {
 			static function ( $a, $b ) {
 				if ( 'force' === $a ) {
 					return 1;
-				} else if ( 'force' === $b ) {
+				} elseif ( 'force' === $b ) {
 					return -1;
 				} else {
 					return 0;

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1618,11 +1618,12 @@ class DB_Command extends WP_CLI_Command {
 		uksort(
 			$final_args,
 			static function ( $a, $b ) {
-				switch ( $b ) {
-					case 'force':
-						return -1;
-					default:
-						return 1;
+				if ( 'force' === $a ) {
+					return 1;
+				} else if ( 'force' === $b ) {
+					return -1;
+				} else {
+					return 0;
 				}
 			}
 		);


### PR DESCRIPTION
WP-CLI v2.6.0 is breaking mysql argument order, apparently due to how arguments are sorted [here](https://github.com/wp-cli/db-command/blob/709f58c30d178afcdecaf56068ca9f5e985ed6b9/src/DB_Command.php#L1617-L1628).

On WordPress.com, with WP-CLI v2.6.0, we discovered this due to backups that were failing because `wp db export` output had changed.

The changed argument order can be observed by reading `--debug` output.

## WP-CLI v2.5.0

For the command:
```bash
wp --path=/srv/htdocs/__wp__/ --skip-plugins --skip-themes db export - --tables=wp_commentmeta --opt --compact --quick --single-transaction --complete-insert --skip-extended-insert --max-allowed-packet=100M --debug
```

WP-CLI v2.5.0 shows the following, where the argument order in the final command generally follows the associative argument order.
```
Debug (db): Associative arguments: {"opt":true,"compact":true,"quick":true,"single-transaction":true,"complete-insert":true,"skip-extended-insert":true,"max-allowed-packet":"100M"} (0.192s)
Debug (db): Final MySQL command: /usr/bin/env mysqldump --no-defaults '149697504' --no-tablespaces --tables 'wp_commentmeta' --opt --compact --quick --single-transaction --complete-insert --skip-extended-insert --max-allowed-packet='100M' --host='127.0.0.1' --user='149697504' --default-character-set='latin1' (0.192s)
```

## WP-CLI v2.6.0

In contrast, WP-CLI v2.6.0 show the following, where the argument order in the final command does not reflect the associative argument order:
```
Debug (db): Associative arguments: {"opt":true,"compact":true,"quick":true,"single-transaction":true,"complete-insert":true,"skip-extended-insert":true,"max-allowed-packet":"100M"} (0.201s)
Debug (db): Final MySQL command: /usr/bin/env mysqldump --no-defaults '149697504' --no-tablespaces --tables 'wp_commentmeta' --skip-extended-insert --max-allowed-packet='100M' --single-transaction --complete-insert --compact --quick --opt --default-character-set='latin1' --user='149697504' --host='127.0.0.1' (0.201s)
```

In this specific case, the difference in argument order causes `mysqldump` to output a single multi-row INSERT statement rather than an INSERT statement per row as the original command specified (with an `--opt` arg followed by `--skip-extended-insert`).

## The Fix

This PR updates the argument sorting to explicitly sort a `force` argument to the end while treating all other arguments as equal so their order, relative to one another, does not change. With this fix, the debug output shows the final command reflects the associate argument order:
```
Debug (db): Associative arguments: {"opt":true,"compact":true,"quick":true,"single-transaction":true,"complete-insert":true,"skip-extended-insert":true,"max-allowed-packet":"100M"} (0.203s)
Debug (db): Final MySQL command: /usr/bin/env mysqldump --no-defaults '149697504' --no-tablespaces --tables 'wp_commentmeta' --host='127.0.0.1' --user='149697504' --default-character-set='latin1' --opt --compact --quick --single-transaction --complete-insert --skip-extended-insert --max-allowed-packet='100M' (0.203s)
```

In addition, testing this fix with a `--force` argument in the middle of the arguments shows that the `--force` argument is moved to the end without affecting the order of the other arguments.
```
Debug (db): Associative arguments: {"opt":true,"compact":true,"force":true,"quick":true,"single-transaction":true,"complete-insert":true,"skip-extended-insert":true,"max-allowed-packet":"100M"} (0.202s)
Debug (db): Final MySQL command: /usr/bin/env mysqldump --no-defaults '149697504' --no-tablespaces --tables 'wp_commentmeta' --host='127.0.0.1' --user='149697504' --default-character-set='latin1' --opt --compact --quick --single-transaction --complete-insert --skip-extended-insert --max-allowed-packet='100M' --force (0.202s)
```