### PR TITLE
Fix broken tests due to DB connection failure error message change

### DIFF
--- a/features/db.feature
+++ b/features/db.feature
@@ -18,7 +18,7 @@ Feature: Perform database operations
     Then STDOUT should be empty
     And STDERR should contain:
       """
-      We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      (which means your username and password is okay)
       """
 
     When I run `wp db create`
@@ -62,7 +62,7 @@ Feature: Perform database operations
     Then STDOUT should be empty
     And STDERR should contain:
       """
-      We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      (which means your username and password is okay)
       """
 
     When I run `wp db create --dbuser=wp_cli_test`


### PR DESCRIPTION
The message that WordPress Core produces when it couldn't connect to the database has changed.

This PR makes the test more flexible to deal with both versions of the error string.