### PR TITLE
Fix retrieval of get_post_table_characterset  

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -657,8 +657,8 @@ class DB_Command extends WP_CLI_Command {
 				. 'FROM information_schema.`TABLES` T, '
 				. 'information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA '
 				. 'WHERE CCSA.collation_name = T.table_collation '
-				. 'AND T.table_schema = "' . DB_NAME . '" '
-				. 'AND T.table_name LIKE "%\_posts";';
+				. "AND T.table_schema = '" . DB_NAME . "' "
+				. "AND T.table_name LIKE '%\_posts';";
 
 		list( $stdout, $stderr, $exit_code ) = self::run(
 			sprintf(


### PR DESCRIPTION
Query command run through `assoc_args_to_str` get double quotes truncated and fail to execute. 

Using single quotes in the query prevent error.

`Warning: Failed to get current character set of the posts table. Reason: ERROR at line 1: Unknown command '\_'`

Error may be more prominent on windows.