### PR TITLE
Document what wp db check doesn't do; provide suggestions for next commands

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -261,8 +261,6 @@ class DB_Command extends WP_CLI_Command {
 
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database checked.' );
-		WP_CLI::log( 'To check whether the WordPress DB tables are installed: wp core is-installed', 'db' );
-		WP_CLI::log( 'To check whether the WordPress DB tables need to be updated: wp core update-db --dry-run', 'db' );
 	}
 
 	/**

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -261,8 +261,8 @@ class DB_Command extends WP_CLI_Command {
 
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database checked.' );
-		WP_CLI::log( 'Check whether the WordPress DB tables are installed: wp core is-installed', 'db' );
-		WP_CLI::log( 'Check whether the WordPress DB tables need to be updated: wp core update-db --dry-run', 'db' );
+		WP_CLI::log( 'To check whether the WordPress DB tables are installed: wp core is-installed', 'db' );
+		WP_CLI::log( 'To check whether the WordPress DB tables need to be updated: wp core update-db --dry-run', 'db' );
 	}
 
 	/**

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -226,6 +226,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [See docs](http://dev.mysql.com/doc/refman/5.7/en/check-table.html)
 	 * for more details on the `CHECK TABLE` statement.
 	 *
+	 * This command does not check whether WordPress is installed;
+	 * to do that run `wp core is-installed`.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--dbuser=<value>]
@@ -258,6 +261,8 @@ class DB_Command extends WP_CLI_Command {
 
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 		WP_CLI::success( 'Database checked.' );
+		WP_CLI::log( 'Check whether the WordPress DB tables are installed: wp core is-installed', 'db' );
+		WP_CLI::log( 'Check whether the WordPress DB tables need to be updated: wp core update-db --dry-run', 'db' );
 	}
 
 	/**


### PR DESCRIPTION

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

## Changes

- adds documentation to note that `wp db check` doesn't check anything WordPress-specific
- adds suggested follow-up commands for checking WordPress-specific parts of the DB

## Why

#148 
