### PR TITLE
Add note about multisite usage in `wp db query` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,29 @@ entirely.
     | 2 | home | http://wordpress-develop.dev | yes |
     +---+------+------------------------------+-----+
 
+**MULTISITE USAGE**
+
+Please note that the global `--url` parameter will have no effect on this command.
+In order to query for data in a site other than your primary site,
+you will need to manually modify the table names to use the prefix that includes the site's ID.
+
+For example, to get the `home` option for your second site, modify the example above like so:
+
+    $ wp db query 'SELECT option_value FROM wp_2_options WHERE option_name="home"' --skip-column-names
+    +----------------------+
+    | https://example2.com |
+    +----------------------+
+
+To confirm the ID for the site you want to query, you can use the `wp site list` command:
+
+    # wp site list --fields=blog_id,url
+    +---------+-----------------------+
+    | blog_id | url                   |
+    +---------+-----------------------+
+    | 1       | https://example1.com/ |
+    | 2       | https://example2.com/ |
+    +---------+-----------------------+
+
 
 
 ### wp db export

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -457,6 +457,29 @@ class DB_Command extends WP_CLI_Command {
 	 *     +---+------+------------------------------+-----+
 	 *     | 2 | home | http://wordpress-develop.dev | yes |
 	 *     +---+------+------------------------------+-----+
+	 * 
+	 * ## MULTISITE USAGE
+	 * 
+	 * Please note that the global `--url` parameter will have no effect on this command.
+	 * In order to query for data in a site other than your primary site,
+	 * you will need to manually modify the table names to use the prefix that includes the site's ID.
+	 * 
+	 * For example, to get the `home` option for your second site, modify the example above like so:
+	 * 
+	 *     $ wp db query 'SELECT option_value FROM wp_2_options WHERE option_name="home"' --skip-column-names
+	 *     +----------------------+
+	 *     | https://example2.com |
+	 *     +----------------------+
+	 * 
+	 * To confirm the ID for the site you want to query, you can use the `wp site list` command:
+	 * 
+	 *     # wp site list --fields=blog_id,url
+	 *     +---------+-----------------------+
+	 *     | blog_id | url                   |
+	 *     +---------+-----------------------+
+	 *     | 1       | https://example1.com/ |
+	 *     | 2       | https://example2.com/ |
+	 *     +---------+-----------------------+
 	 */
 	public function query( $args, $assoc_args ) {
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -457,22 +457,22 @@ class DB_Command extends WP_CLI_Command {
 	 *     +---+------+------------------------------+-----+
 	 *     | 2 | home | http://wordpress-develop.dev | yes |
 	 *     +---+------+------------------------------+-----+
-	 * 
+	 *
 	 * ## MULTISITE USAGE
-	 * 
+	 *
 	 * Please note that the global `--url` parameter will have no effect on this command.
 	 * In order to query for data in a site other than your primary site,
 	 * you will need to manually modify the table names to use the prefix that includes the site's ID.
-	 * 
+	 *
 	 * For example, to get the `home` option for your second site, modify the example above like so:
-	 * 
+	 *
 	 *     $ wp db query 'SELECT option_value FROM wp_2_options WHERE option_name="home"' --skip-column-names
 	 *     +----------------------+
 	 *     | https://example2.com |
 	 *     +----------------------+
-	 * 
+	 *
 	 * To confirm the ID for the site you want to query, you can use the `wp site list` command:
-	 * 
+	 *
 	 *     # wp site list --fields=blog_id,url
 	 *     +---------+-----------------------+
 	 *     | blog_id | url                   |


### PR DESCRIPTION
I was caught out by the fact that the global `--url` parameter, normally used to target a non-primary site in a multisite setup, has no effect on the `wb db query` command, so I thought I'd propose adding a note about it.