### PR TITLE
Update tests after change in WP trunk

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -24,11 +24,14 @@ Feature: Search through the database
       4:example.com example.com
       """
 
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'siteurl';" --skip-column-names | cat`
+    Then save STDOUT as {SITEURL_ID}
+
     When I run `wp db search example.com`
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -44,7 +47,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -60,7 +63,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should not contain:
       """
@@ -79,7 +82,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should contain:
       """
@@ -105,7 +108,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should not contain:
       """
@@ -121,7 +124,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should not contain:
       """
@@ -148,7 +151,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should contain:
       """
@@ -174,7 +177,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:example.com
+      {SITEURL_ID}:example.com
       """
     And STDOUT should contain:
       """
@@ -290,6 +293,9 @@ Feature: Search through the database
     And I run `wp db query "CREATE TABLE pw_options ( id int(11) unsigned NOT NULL AUTO_INCREMENT, awesome_stuff TEXT, PRIMARY KEY (id) );"`
     And I run `wp db query "INSERT INTO pw_options (awesome_stuff) VALUES ('example.com'), ('e_ample.c%m');"`
 
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'siteurl';" --skip-column-names | cat`
+    Then save STDOUT as {SITEURL_ID}
+
     When I run `wp db query "SELECT CONCAT( id, ':', awesome_stuff) FROM wp_not ORDER BY id;" --skip-column-names`
     Then STDOUT should be:
       """
@@ -313,7 +319,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -337,7 +343,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -385,12 +391,12 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should contain:
       """
       wp_2_options:option_value
-      1:https://example.com/foo
+      {SITEURL_ID}:https://example.com/foo
       """
     And STDOUT should not contain:
       """
@@ -410,7 +416,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -434,7 +440,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should contain:
       """
@@ -461,7 +467,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -510,7 +516,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should contain:
       """
@@ -538,7 +544,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should contain:
       """
@@ -705,6 +711,9 @@ Feature: Search through the database
 
   Scenario: Search with regular expressions
     Given a WP install
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'siteurl';" --skip-column-names | cat`
+    Then save STDOUT as {SITEURL_ID}
+
     And I run `wp option update regextst '12345é789あhttps://regextst.com1234567890123456789éhttps://regextst.com12345678901234567890regextst.com34567890t.com67890'`
     # Note ö is o with combining umlaut.
     And I run `wp option update regextst_combining 'lllllムnöppppp'`
@@ -713,7 +722,7 @@ Feature: Search through the database
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       """
     And STDOUT should not contain:
       """
@@ -865,35 +874,41 @@ Feature: Search through the database
   Scenario: Search with output options
     Given a WP install
 
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'siteurl';" --skip-column-names | cat`
+    Then save STDOUT as {SITEURL_ID}
+
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'home';" --skip-column-names | cat`
+    Then save STDOUT as {HOMEURL_ID}
+
     When I run `wp db search example.com`
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
+      {SITEURL_ID}:https://example.com
       wp_options:option_value
-      2:https://example.com
+      {HOMEURL_ID}:https://example.com
       """
 
     When I run `wp db search example.com --table_column_once`
     Then STDOUT should contain:
       """
       wp_options:option_value
-      1:https://example.com
-      2:https://example.com
+      {SITEURL_ID}:https://example.com
+      {HOMEURL_ID}:https://example.com
       """
 
     When I run `wp db search example.com --one_line`
     Then STDOUT should contain:
       """
-      wp_options:option_value:1:https://example.com
-      wp_options:option_value:2:https://example.com
+      wp_options:option_value:{SITEURL_ID}:https://example.com
+      wp_options:option_value:{HOMEURL_ID}:https://example.com
       """
 
     When I run `wp db search example.com --table_column_once --one_line`
     Then STDOUT should contain:
       """
-      wp_options:option_value:1:https://example.com
-      wp_options:option_value:2:https://example.com
+      wp_options:option_value:{SITEURL_ID}:https://example.com
+      wp_options:option_value:{HOMEURL_ID}:https://example.com
       """
 
     When I run `wp db search example.com --all-tables --before_context=0 --after_context=0 --matches_only`
@@ -917,46 +932,49 @@ Feature: Search through the database
   Scenario: Search with custom colors
     Given a WP install
 
+    When I run `wp db query "SELECT option_id FROM wp_options WHERE option_name = 'siteurl';" --skip-column-names | cat`
+    Then save STDOUT as {SITEURL_ID}
+
     When I run `SHELL_PIPE=0 wp db search example.com`
     Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
-      [33;1m1[0m:https://[43m[30mexample.com[0m
+      [33;1m{SITEURL_ID}[0m:https://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --table_column_color=%r --id_color=%g --match_color=%b`
     Then STDOUT should strictly contain:
       """
       [31mwp_options:option_value[0m
-      [32m1[0m:https://[34mexample.com[0m
+      [32m{SITEURL_ID}[0m:https://[34mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --table_column_color=%r`
     Then STDOUT should strictly contain:
       """
       [31mwp_options:option_value[0m
-      [33;1m1[0m:https://[43m[30mexample.com[0m
+      [33;1m{SITEURL_ID}[0m:https://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --id_color=%g`
     Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
-      [32m1[0m:https://[43m[30mexample.com[0m
+      [32m{SITEURL_ID}[0m:https://[43m[30mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --match_color=%b`
     Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
-      [33;1m1[0m:https://[34mexample.com[0m
+      [33;1m{SITEURL_ID}[0m:https://[34mexample.com[0m
       """
 
     When I run `SHELL_PIPE=0 wp db search example.com --before_context=0 --after_context=0`
     Then STDOUT should strictly contain:
       """
       [32;1mwp_options:option_value[0m
-      [33;1m1[0m:example.com
+      [33;1m{SITEURL_ID}[0m:example.com
       """
 
     When I try `wp db search example.com --match_color=%x`


### PR DESCRIPTION
The `siteurl` option is no longer guaranteed to have ID number 1.

Change introduced in https://github.com/WordPress/wordpress-develop/commit/199bc9d6ca29c2b5ac093ea8170efac1b68c32f8 / https://core.trac.wordpress.org/ticket/61457