### PR TITLE
Correct error message in db search for `--format=count`

### DIFF
--- a/features/db-search.feature
+++ b/features/db-search.feature
@@ -1102,5 +1102,13 @@ Feature: Search through the database
     And STDOUT should be empty
     And the return code should be 1
 
+    When I try `wp db search example.com --format=count`
+    Then STDERR should be:
+      """
+      Error: The "count" format can only be used for a single table.
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
     When I run `wp db search mail.example.com wp_options --format=ids`
     Then STDOUT should not be empty

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1553,7 +1553,7 @@ class DB_Command extends WP_CLI_Command {
 
 			if ( in_array( $format, [ 'ids', 'count' ], true ) ) {
 				if ( count( $tables ) > 1 ) {
-					WP_CLI::error( 'The "ids" format can only be used for a single table.' );
+					WP_CLI::error( "The \"{$format}\" format can only be used for a single table." );
 				}
 				$search_results = array_column( $search_results, 'primary_key_value' );
 			}


### PR DESCRIPTION
Fixes https://github.com/wp-cli/db-command/issues/266

* Correct error message for `count` format in db search command 