### PR TITLE
Handle MySQL commands without deprecation warnings

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2168,9 +2168,7 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	private static function sanitize_mysql_command( $command, $default_flags ) {
 		return sprintf(
-			'/usr/bin/env $(test -L $(command -v %s) && /usr/bin/readlink -f $(command -v %s) || command -v %s)%s',
-			$command,
-			$command,
+			'/usr/bin/env $(/usr/bin/readlink -f $(command -v %s))%s',
 			$command,
 			$default_flags
 		);


### PR DESCRIPTION
With this fix:

```
% ./vendor/bin/wp db check --path=/tmp/wordpress
mariadb-check: ...
```

Issue: https://github.com/wp-cli/db-command/issues/271

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
