### PR TITLE
Don't hardcode MySQL command names

### DIFF
--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -128,19 +128,11 @@ Feature: Check the database
     Given a WP install
 
     When I try `wp db check --defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysqlcheck %s
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) %s#
 
     When I try `wp db check --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysqlcheck --no-defaults %s
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) --no-defaults %s#
 
     When I try `wp db check --no-defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysqlcheck --no-defaults %s
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) --no-defaults %s#
+

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -82,19 +82,10 @@ Feature: Export a WordPress database
     Given a WP install
 
     When I try `wp db export --defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running initial shell command: /usr/bin/env mysqldump
-      """
+    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump)#
 
     When I try `wp db export --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running initial shell command: /usr/bin/env mysqldump --no-defaults
-      """
+    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump) --no-defaults#
 
     When I try `wp db export --no-defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running initial shell command: /usr/bin/env mysqldump --no-defaults
-      """
+    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump) --no-defaults#

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -250,7 +250,12 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function check( $_, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
+		$command = sprintf(
+			'/usr/bin/env %s%s %s',
+			$this->get_check_command(),
+			$this->get_defaults_flag_string( $assoc_args ),
+			'%s'
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['check'] = true;
@@ -293,8 +298,12 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database optimized.
 	 */
 	public function optimize( $_, $assoc_args ) {
-
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
+		$command = sprintf(
+			'/usr/bin/env %s%s %s',
+			$this->get_check_command(),
+			$this->get_defaults_flag_string( $assoc_args ),
+			'%s'
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['optimize'] = true;
@@ -337,8 +346,12 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Database repaired.
 	 */
 	public function repair( $_, $assoc_args ) {
-
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
+		$command = sprintf(
+			'/usr/bin/env %s%s %s',
+			$this->get_check_command(),
+			$this->get_defaults_flag_string( $assoc_args ),
+			'%s'
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['repair'] = true;
@@ -611,7 +624,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['result-file'] = $result_file;
 		}
 
-		$mysqldump_binary = Utils\force_env_on_nix_systems( 'mysqldump' );
+		$mysqldump_binary = Utils\force_env_on_nix_systems( $this->get_dump_command() );
 
 		$support_column_statistics = exec( $mysqldump_binary . ' --help | grep "column-statistics"' );
 
@@ -2151,5 +2164,23 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return $modes;
+	}
+
+	/**
+	 * Returns the correct `check` command based on the detected database type.
+	 *
+	 * @return string The appropriate check command.
+	 */
+	private function get_check_command() {
+		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb-check' : 'mysqlcheck';
+	}
+
+	/**
+	 * Returns the correct `dump` command based on the detected database type.
+	 *
+	 * @return string The appropriate dump command.
+	 */
+	private function get_dump_command() {
+		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb-dump' : 'mysqldump';
 	}
 }


### PR DESCRIPTION
The compatibility links MariaDB provides for MySQL commands are deprecated and will be removed in the future. We should use the MariaDB command name if that is the current MySQL provider.

Fixes #271

(We still use `mysql` all over the place in wp-cli, but that isn't going away from MariaDB.) 