### PR TITLE
Only unset defaults before running command.

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1768,6 +1768,10 @@ class DB_Command extends WP_CLI_Command {
 			'pass' => DB_PASSWORD,
 		];
 
+		if ( array_key_exists( 'defaults', $assoc_args ) ) {
+			unset( $assoc_args['defaults'] );
+		}
+
 		if ( ! isset( $assoc_args['default-character-set'] )
 			&& defined( 'DB_CHARSET' ) && constant( 'DB_CHARSET' ) ) {
 			$required['default-character-set'] = constant( 'DB_CHARSET' );
@@ -2050,8 +2054,6 @@ class DB_Command extends WP_CLI_Command {
 			if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
 				$flag_string = '';
 			}
-
-			unset( $assoc_args['defaults'] );
 
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2054,7 +2054,6 @@ class DB_Command extends WP_CLI_Command {
 			if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
 				$flag_string = '';
 			}
-
 		}
 
 		return $flag_string;

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2226,7 +2226,7 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative args array.
 	 * @return string Either the '--no-defaults' flag for use in the command or an empty string.
 	 */
-	protected function get_defaults_flag_string( &$assoc_args ) {
+	protected function get_defaults_flag_string( $assoc_args ) {
 
 		$flag_string = ' --no-defaults';
 


### PR DESCRIPTION
Allow defaults to be used in querying the SQL mode

Fixes #278

