### PR TITLE
Improve MariaDB detection/compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "wp-cli/wp-cli": "dev-try/mariadb-detection as 2.12"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "wp-cli/wp-cli": "^2.12"
+        "wp-cli/wp-cli": "dev-try/mariadb-detection as 2.12"
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -135,22 +135,13 @@ Feature: Import a WordPress database
     Then the wp_cli_test.sql file should exist
 
     When I try `wp db import --defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-auto-rehash#
 
     When I try `wp db import --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
     When I try `wp db import --no-defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
   @require-wp-4.2
   Scenario: Import db that has emoji in post

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -76,22 +76,13 @@ Feature: Query the database with WordPress' MySQL config
     Given a WP install
 
   When I try `wp db query --defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-auto-rehash#
 
     When I try `wp db query --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
     When I try `wp db query --no-defaults --debug`
-    Then STDERR should contain:
-      """
-      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
-      """
+    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
   Scenario: SQL modes do not include any of the modes incompatible with WordPress
     Given a WP install

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2167,7 +2167,7 @@ class DB_Command extends WP_CLI_Command {
 			list( $stdout, $stderr, $exit_code ) = self::run(
 				sprintf(
 					'%s%s --no-auto-rehash --batch --skip-column-names',
-					$this->get_mysql_command(),
+					Utils\get_mysql_binary_path(),
 					$this->get_defaults_flag_string( $assoc_args )
 				),
 				array_merge( $args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -829,7 +829,7 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		$command = sprintf(
-			'%s%s --no-auto-rehash',
+			'/usr/bin/env %s%s --no-auto-rehash',
 			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -398,7 +398,7 @@ class DB_Command extends WP_CLI_Command {
 	public function cli( $_, $assoc_args ) {
 
 		$command = sprintf(
-			'%s%s --no-auto-rehash',
+			'/usr/bin/env %s%s --no-auto-rehash',
 			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
@@ -501,7 +501,7 @@ class DB_Command extends WP_CLI_Command {
 	public function query( $args, $assoc_args ) {
 
 		$command = sprintf(
-			'%s%s --no-auto-rehash',
+			'/usr/bin/env %s%s --no-auto-rehash',
 			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -397,7 +397,11 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function cli( $_, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		$command = sprintf(
+			'/usr/bin/env %s%s --no-auto-rehash',
+			$this->get_mysql_command(),
+			$this->get_defaults_flag_string( $assoc_args )
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		if ( ! isset( $assoc_args['database'] ) ) {
@@ -496,7 +500,11 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function query( $args, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		$command = sprintf(
+			'/usr/bin/env %s%s --no-auto-rehash',
+			$this->get_mysql_command(),
+			$this->get_defaults_flag_string( $assoc_args )
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['database'] = DB_NAME;
@@ -732,7 +740,8 @@ class DB_Command extends WP_CLI_Command {
 
 		list( $stdout, $stderr, $exit_code ) = self::run(
 			sprintf(
-				'/usr/bin/env mysql%s --no-auto-rehash --batch --skip-column-names',
+				'/usr/bin/env %s%s --no-auto-rehash --batch --skip-column-names',
+				$this->get_mysql_command(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			[ 'execute' => $query ],
@@ -819,7 +828,11 @@ class DB_Command extends WP_CLI_Command {
 			$result_file = 'STDIN';
 		}
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		$command = sprintf(
+			'/usr/bin/env %s%s --no-auto-rehash',
+			$this->get_mysql_command(),
+			$this->get_defaults_flag_string( $assoc_args )
+		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
 
@@ -1752,7 +1765,8 @@ class DB_Command extends WP_CLI_Command {
 
 		self::run(
 			sprintf(
-				'/usr/bin/env mysql%s --no-auto-rehash',
+				'/usr/bin/env %s%s --no-auto-rehash',
+				$this->get_mysql_command(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			array_merge( [ 'execute' => $query ], $mysql_args )
@@ -2152,7 +2166,8 @@ class DB_Command extends WP_CLI_Command {
 
 			list( $stdout, $stderr, $exit_code ) = self::run(
 				sprintf(
-					'/usr/bin/env mysql%s --no-auto-rehash --batch --skip-column-names',
+					'/usr/bin/env %s%s --no-auto-rehash --batch --skip-column-names',
+					$this->get_mysql_command(),
 					$this->get_defaults_flag_string( $assoc_args )
 				),
 				array_merge( $args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),
@@ -2182,6 +2197,15 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return $modes;
+	}
+
+	/**
+	 * Returns the correct `mysql` command based on the detected database type.
+	 *
+	 * @return string The appropriate check command.
+	 */
+	private function get_mysql_command() {
+		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb' : 'mysql';
 	}
 
 	/**

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -398,8 +398,8 @@ class DB_Command extends WP_CLI_Command {
 	public function cli( $_, $assoc_args ) {
 
 		$command = sprintf(
-			'/usr/bin/env %s%s --no-auto-rehash',
-			$this->get_mysql_command(),
+			'%s%s --no-auto-rehash',
+			Utils\get_mysql_binary_path(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -501,8 +501,8 @@ class DB_Command extends WP_CLI_Command {
 	public function query( $args, $assoc_args ) {
 
 		$command = sprintf(
-			'/usr/bin/env %s%s --no-auto-rehash',
-			$this->get_mysql_command(),
+			'%s%s --no-auto-rehash',
+			Utils\get_mysql_binary_path(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -740,8 +740,8 @@ class DB_Command extends WP_CLI_Command {
 
 		list( $stdout, $stderr, $exit_code ) = self::run(
 			sprintf(
-				'/usr/bin/env %s%s --no-auto-rehash --batch --skip-column-names',
-				$this->get_mysql_command(),
+				'%s%s --no-auto-rehash --batch --skip-column-names',
+				Utils\get_mysql_binary_path(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			[ 'execute' => $query ],
@@ -829,8 +829,8 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		$command = sprintf(
-			'/usr/bin/env %s%s --no-auto-rehash',
-			$this->get_mysql_command(),
+			'%s%s --no-auto-rehash',
+			Utils\get_mysql_binary_path(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -1765,8 +1765,8 @@ class DB_Command extends WP_CLI_Command {
 
 		self::run(
 			sprintf(
-				'/usr/bin/env %s%s --no-auto-rehash',
-				$this->get_mysql_command(),
+				'%s%s --no-auto-rehash',
+				Utils\get_mysql_binary_path(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			array_merge( [ 'execute' => $query ], $mysql_args )
@@ -2166,7 +2166,7 @@ class DB_Command extends WP_CLI_Command {
 
 			list( $stdout, $stderr, $exit_code ) = self::run(
 				sprintf(
-					'/usr/bin/env %s%s --no-auto-rehash --batch --skip-column-names',
+					'%s%s --no-auto-rehash --batch --skip-column-names',
 					$this->get_mysql_command(),
 					$this->get_defaults_flag_string( $assoc_args )
 				),
@@ -2200,21 +2200,12 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Returns the correct `mysql` command based on the detected database type.
-	 *
-	 * @return string The appropriate check command.
-	 */
-	private function get_mysql_command() {
-		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb' : 'mysql';
-	}
-
-	/**
 	 * Returns the correct `check` command based on the detected database type.
 	 *
 	 * @return string The appropriate check command.
 	 */
 	private function get_check_command() {
-		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb-check' : 'mysqlcheck';
+		return 'mariadb' === Utils\get_db_type() ? 'mariadb-check' : 'mysqlcheck';
 	}
 
 	/**
@@ -2223,6 +2214,6 @@ class DB_Command extends WP_CLI_Command {
 	 * @return string The appropriate dump command.
 	 */
 	private function get_dump_command() {
-		return ( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false ) ? 'mariadb-dump' : 'mysqldump';
+		return 'mariadb' === Utils\get_db_type() ? 'mariadb-dump' : 'mysqldump';
 	}
 }

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -399,7 +399,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf(
 			'%s%s --no-auto-rehash',
-			Utils\get_mysql_binary_path(),
+			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -502,7 +502,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf(
 			'%s%s --no-auto-rehash',
-			Utils\get_mysql_binary_path(),
+			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -741,7 +741,7 @@ class DB_Command extends WP_CLI_Command {
 		list( $stdout, $stderr, $exit_code ) = self::run(
 			sprintf(
 				'%s%s --no-auto-rehash --batch --skip-column-names',
-				Utils\get_mysql_binary_path(),
+				$this->get_mysql_command(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			[ 'execute' => $query ],
@@ -830,7 +830,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf(
 			'%s%s --no-auto-rehash',
-			Utils\get_mysql_binary_path(),
+			$this->get_mysql_command(),
 			$this->get_defaults_flag_string( $assoc_args )
 		);
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
@@ -1766,7 +1766,7 @@ class DB_Command extends WP_CLI_Command {
 		self::run(
 			sprintf(
 				'%s%s --no-auto-rehash',
-				Utils\get_mysql_binary_path(),
+				$this->get_mysql_command(),
 				$this->get_defaults_flag_string( $assoc_args )
 			),
 			array_merge( [ 'execute' => $query ], $mysql_args )
@@ -2167,7 +2167,7 @@ class DB_Command extends WP_CLI_Command {
 			list( $stdout, $stderr, $exit_code ) = self::run(
 				sprintf(
 					'%s%s --no-auto-rehash --batch --skip-column-names',
-					Utils\get_mysql_binary_path(),
+					$this->get_mysql_command(),
 					$this->get_defaults_flag_string( $assoc_args )
 				),
 				array_merge( $args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),
@@ -2197,6 +2197,15 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return $modes;
+	}
+
+	/**
+	 * Returns the correct `mysql` command based on the detected database type.
+	 *
+	 * @return string The appropriate check command.
+	 */
+	private function get_mysql_command() {
+		return 'mariadb' === Utils\get_db_type() ? 'mariadb' : 'mysql';
 	}
 
 	/**

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -252,7 +252,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$command = sprintf(
 			'/usr/bin/env %s%s %s',
-			$this->get_check_command(),
+			Utils\get_sql_check_command(),
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -300,7 +300,7 @@ class DB_Command extends WP_CLI_Command {
 	public function optimize( $_, $assoc_args ) {
 		$command = sprintf(
 			'/usr/bin/env %s%s %s',
-			$this->get_check_command(),
+			Utils\get_sql_check_command(),
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -348,7 +348,7 @@ class DB_Command extends WP_CLI_Command {
 	public function repair( $_, $assoc_args ) {
 		$command = sprintf(
 			'/usr/bin/env %s%s %s',
-			$this->get_check_command(),
+			Utils\get_sql_check_command(),
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -650,7 +650,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['result-file'] = $result_file;
 		}
 
-		$mysqldump_binary = Utils\force_env_on_nix_systems( $this->get_dump_command() );
+		$mysqldump_binary = Utils\force_env_on_nix_systems( Utils\get_sql_dump_command() );
 
 		$support_column_statistics = exec( $mysqldump_binary . ' --help | grep "column-statistics"' );
 
@@ -2206,23 +2206,5 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	private function get_mysql_command() {
 		return 'mariadb' === Utils\get_db_type() ? 'mariadb' : 'mysql';
-	}
-
-	/**
-	 * Returns the correct `check` command based on the detected database type.
-	 *
-	 * @return string The appropriate check command.
-	 */
-	private function get_check_command() {
-		return 'mariadb' === Utils\get_db_type() ? 'mariadb-check' : 'mysqlcheck';
-	}
-
-	/**
-	 * Returns the correct `dump` command based on the detected database type.
-	 *
-	 * @return string The appropriate dump command.
-	 */
-	private function get_dump_command() {
-		return 'mariadb' === Utils\get_db_type() ? 'mariadb-dump' : 'mysqldump';
 	}
 }


### PR DESCRIPTION
This is a follow-up to #275 which addressed the `mysqlcheck` and `mysqldump` usage, but not usage of `mysql` itself.

There was a suggestion to move this utility to the main framework (maybe updating [`Utils/get_mysql_binary_path()`](https://github.com/wp-cli/wp-cli/blob/279794bce3f5b92d7fd92e4559061921f433bf64/php/utils.php#L1820-L1839)?) which we could do in a future step.

Then, we could also add a `get_db_type()` util or so to avoid repeating `( strpos( Utils\get_mysql_version(), 'MariaDB' ) !== false )` everywhere.