### PR TITLE
Try refactor `wp db query --defaults` handling

### DIFF
--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -98,7 +98,7 @@ Feature: Query the database with WordPress' MySQL config
     Given a WP install
 
     When I try `wp db query "SELECT 1;" --host=testhost --port=3307 --debug`
-    Then STDERR should match #Final MySQL command: .* --host=testhost.*--port=3307#
+    Then STDERR should match #Running shell command: .* --host=testhost.*--port=3307#
 
   Scenario: SQL modes do not include any of the modes incompatible with WordPress
     Given a WP install

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -94,6 +94,12 @@ Feature: Query the database with WordPress' MySQL config
     When I try `wp db query "SELECT 1;" --debug`
     Then STDERR should match #Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
+  Scenario: SQL mode discovery preserves MySQL connection arguments
+    Given a WP install
+
+    When I try `wp db query "SELECT 1;" --host=testhost --port=3307 --debug`
+    Then STDERR should match #Final MySQL command: .* --host=testhost.*--port=3307#
+
   Scenario: SQL modes do not include any of the modes incompatible with WordPress
     Given a WP install
 

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -84,6 +84,16 @@ Feature: Query the database with WordPress' MySQL config
     When I try `wp db query --no-defaults --debug`
     Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
 
+  Scenario: SQL mode discovery respects --defaults flag
+    Given a WP install
+
+    When I try `wp db query "SELECT 1;" --defaults --debug`
+    Then STDERR should match #Running shell command: /usr/bin/env (mysql|mariadb) --no-auto-rehash#
+    And STDERR should not match #Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults#
+
+    When I try `wp db query "SELECT 1;" --debug`
+    Then STDERR should match #Running shell command: /usr/bin/env (mysql|mariadb) --no-defaults --no-auto-rehash#
+
   Scenario: SQL modes do not include any of the modes incompatible with WordPress
     Given a WP install
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2052,6 +2052,7 @@ class DB_Command extends WP_CLI_Command {
 			'ssl-fips-mode',
 			'ssl-key',
 			'ssl-mode',
+			'ssl-verify-server-cert',
 			'syslog',
 			'table',
 			'tee',
@@ -2162,13 +2163,8 @@ class DB_Command extends WP_CLI_Command {
 		static $modes = null;
 
 		// Make sure the provided arguments don't interfere with the expected
-		// output here.
-		$args = [];
-		foreach ( [] as $arg ) {
-			if ( isset( $assoc_args[ $arg ] ) ) {
-				$args[ $arg ] = $assoc_args[ $arg ];
-			}
-		}
+		// output here. We need to preserve all valid MySQL arguments for connection.
+		$args = self::get_mysql_args( $assoc_args );
 
 		if ( null === $modes ) {
 			$modes = [];

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -2176,7 +2176,10 @@ class DB_Command extends WP_CLI_Command {
 		static $modes = null;
 
 		// Make sure the provided arguments don't interfere with the expected
-		// output here. We need to preserve all valid MySQL arguments for connection.
+		// output here, while preserving all valid MySQL connection arguments
+		// (including --defaults, --host, --port, --ssl-* options) so that SQL
+		// mode discovery connects to the database with the same configuration
+		// as the main query.
 		$args = self::get_mysql_args( $assoc_args );
 
 		if ( null === $modes ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -500,6 +500,9 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function query( $args, $assoc_args ) {
 
+		// Preserve the original defaults flag value before get_defaults_flag_string modifies $assoc_args.
+		$original_assoc_args_for_sql_mode = $assoc_args;
+
 		$command = sprintf(
 			'/usr/bin/env %s%s --no-auto-rehash',
 			$this->get_mysql_command(),
@@ -516,7 +519,7 @@ class DB_Command extends WP_CLI_Command {
 
 		if ( isset( $assoc_args['execute'] ) ) {
 			// Ensure that the SQL mode is compatible with WPDB.
-			$assoc_args['execute'] = $this->get_sql_mode_query( $assoc_args ) . $assoc_args['execute'];
+			$assoc_args['execute'] = $this->get_sql_mode_query( $original_assoc_args_for_sql_mode ) . $assoc_args['execute'];
 		}
 
 		$is_row_modifying_query = isset( $assoc_args['execute'] ) && preg_match( '/\b(UPDATE|DELETE|INSERT|REPLACE|LOAD DATA)\b/i', $assoc_args['execute'] );
@@ -805,6 +808,9 @@ class DB_Command extends WP_CLI_Command {
 			$result_file = sprintf( '%s.sql', DB_NAME );
 		}
 
+		// Preserve the original defaults flag value before get_defaults_flag_string modifies $assoc_args.
+		$original_assoc_args_for_sql_mode = $assoc_args;
+
 		// Process options to MySQL.
 		$mysql_args = array_merge(
 			[ 'database' => DB_NAME ],
@@ -821,7 +827,7 @@ class DB_Command extends WP_CLI_Command {
 				? 'SOURCE %s;'
 				: 'SET autocommit = 0; SET unique_checks = 0; SET foreign_key_checks = 0; SOURCE %s; COMMIT;';
 
-			$query = $this->get_sql_mode_query( $assoc_args ) . $query;
+			$query = $this->get_sql_mode_query( $original_assoc_args_for_sql_mode ) . $query;
 
 			$mysql_args['execute'] = sprintf( $query, $result_file );
 		} else {
@@ -1753,8 +1759,11 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array  $assoc_args Optional. Associative array of arguments.
 	 */
 	protected function run_query( $query, $assoc_args = [] ) {
+		// Preserve the original defaults flag value before get_defaults_flag_string modifies $assoc_args.
+		$original_assoc_args_for_sql_mode = $assoc_args;
+
 		// Ensure that the SQL mode is compatible with WPDB.
-		$query = $this->get_sql_mode_query( $assoc_args ) . $query;
+		$query = $this->get_sql_mode_query( $original_assoc_args_for_sql_mode ) . $query;
 
 		WP_CLI::debug( "Query: {$query}", 'db' );
 


### PR DESCRIPTION
Try fix #237 

Code change is all Copilot.

I reviewed it for general sanity, but I simply don't know enough `wp db` internals to know whether this direction is where we want to go.

But I'll file this anyway to get movement and directional discussion going.

I feel like currently `wp db query` just doing `--no-defaults` basically hard-coded is overly naive for many real world use cases, and needs to be refactored no matter what. If you can't even connect to remote SSL-secured databases, I'm not sure how we can ignore this in 2025.

My Copilot strategy session can be reviewed at https://github.com/lkraav/db-command/pull/2

EDIT I've now also tested it, and this PR does make at least `--defaults` and/or `--ssl-verify-server-cert`  work.