### PR TITLE
Fix: Skip sandbox line in MariaDB dump files during import

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -816,26 +816,32 @@ class DB_Command extends WP_CLI_Command {
 			if ( ! is_readable( $result_file ) ) {
 				WP_CLI::error( sprintf( 'Import file missing or not readable: %s', $result_file ) );
 			}
-		
-		// Check for MariaDB sandbox directive and skip it if found
-		$first_line = fgets( fopen( $result_file, 'r' ) );
-		if ( strpos( $first_line, '/*!999999\\' ) !== false ) {
-			WP_CLI::debug( 'MariaDB sandbox directive found. Creating sanitized temp file.', 'db' );
 
-			$input = fopen( $result_file, 'r' );
-			$tmp   = tmpfile();
-			$tmp_path = stream_get_meta_data( $tmp )['uri'];
+			// Check for MariaDB sandbox directive and skip it if found
+			$first_line = fgets( fopen( $result_file, 'r' ) );
+			if ( strpos( $first_line, '/*!999999\\' ) !== false ) {
+				WP_CLI::debug( 'MariaDB sandbox directive found. Creating sanitized temp file.', 'db' );
 
-			$line_number = 0;
-			while ( ( $line = fgets( $input ) ) !== false ) {
-				if ( $line_number > 0 ) {
-					fwrite( $tmp, $line );
+				$input       = fopen( $result_file, 'r' );
+				$tmp         = tmpfile();
+				$tmp_path    = stream_get_meta_data( $tmp )['uri'];
+				$line_number = 0;
+
+				while ( true ) {
+					$line = fgets( $input );
+					if ( false === $line ) {
+						break;
+					}
+
+					if ( $line_number > 0 ) {
+						fwrite( $tmp, $line );
+					}
+
+					++$line_number; // Use pre-increment
 				}
-				$line_number++;
-			}
-			fclose( $input );
 
-			$result_file = $tmp_path;
+				fclose( $input );
+				$result_file = $tmp_path;
 			}
 
 			$query = Utils\get_flag_value( $assoc_args, 'skip-optimization' )


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

### Summary

This PR addresses a compatibility issue introduced by a recent MariaDB security fix ([MDEV-21178](https://jira.mariadb.org/browse/MDEV-21178)), which causes `wp db import` to fail when importing SQL dump files generated by newer versions of MariaDB.

---

### Background

To mitigate a serious security vulnerability, MariaDB added a new "sandbox mode" that disables potentially dangerous client-side commands. This mode is triggered by placing the following directive at the top of a dump file:

```sql
/*!999999\ - enable the sandbox mode */
```

While this is safe for newer MariaDB clients, it breaks compatibility with:

-    Older MariaDB clients
-    All versions of MySQL clients
-    WP-CLI's wp db import command

This directive causes a SQL syntax error when encountered during import:

```ERROR 1064 (42000): You have an error in your SQL syntax...```

This problem is being tracked in WP-CLI/db-command#258.

### Solution
This patch introduces a safeguard into the import() method:

-    It reads the first line of the SQL dump.
-    If the line contains the sandbox directive (/*!999999\), it creates a temporary file that skips the first line.
-    The modified file is then passed into the SOURCE command for import.
-    If the directive is not found, import proceeds as normal.