### PR TITLE
Fix missing table on wb db query output

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -526,18 +526,17 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		WP_CLI::debug( 'Associative arguments: ' . json_encode( $assoc_args ), 'db' );
-		list( $stdout, $stderr, $exit_code ) = self::run( $command, $assoc_args, false );
-
-		if ( $exit_code ) {
-			WP_CLI::error( "Query failed: {$stderr}" );
-		}
 
 		if ( $is_row_modifying_query ) {
-			$output_lines  = explode( "\n", trim( $stdout ) );
-			$affected_rows = (int) trim( end( $output_lines ) );
+			list( $stdout, $stderr, $exit_code ) = self::run( $command, $assoc_args, false );
+			$output_lines                        = explode( "\n", trim( $stdout ) );
+			$affected_rows                       = (int) trim( end( $output_lines ) );
+			if ( $exit_code ) {
+				WP_CLI::error( "Query failed: {$stderr}" );
+			}
 			WP_CLI::success( "Query succeeded. Rows affected: {$affected_rows}" );
-		} elseif ( ! empty( $stdout ) ) {
-			WP_CLI::line( $stdout );
+		} else {
+			self::run( $command, $assoc_args );
 		}
 	}
 


### PR DESCRIPTION
In #277 this code was changed in order to support a count number for certain types of queries. That change had a side effect of removing the default table that MySQL/MariaDB prints for regular queries because that relies on TTY detection from MySQL/MariaDB itself. To revert to preivious behavior, only run the new code if we know it is a row modifying query that will just print the count. Otherwise, use the previous code path so things work exactly as they did before.

Fixes #290