### PR TITLE
Fix `db sizes` test for WP trunk

### DIFF
--- a/features/db-size.feature
+++ b/features/db-size.feature
@@ -20,10 +20,7 @@ Feature: Display database size
     Given a WP install
 
     When I run `wp db size --tables`
-    Then STDOUT should contain:
-      """
-      wp_posts	81920 B
-      """
+    Then STDOUT should match /wp_posts\s+\d+ B/
 
     But STDOUT should not contain:
       """


### PR DESCRIPTION
This test was way too brittle.

The default table size in WP core seems to have changed from  81920 B to 98304 B.

Updating the test to use a regex is more future proof.