### PR TITLE
feat: add support for excluding table data during export

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ To confirm the ID for the site you want to query, you can use the `wp site list`
 Exports the database to a file or to STDOUT.
 
 ~~~
-wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--include-tablespaces] [--porcelain] [--add-drop-table] [--defaults]
+wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--exclude_tables_data=<tables>] [--include-tablespaces] [--porcelain] [--add-drop-table] [--defaults]
 ~~~
 
 Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
@@ -455,6 +455,9 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 
 	[--exclude_tables=<tables>]
 		The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database.
+
+	[--exclude_tables_data=<tables>]
+		The comma separated list of specific tables for which only the structure will be exported. Excluding this parameter will export data for all tables in the export.
 
 	[--include-tablespaces]
 		Skips adding the default --no-tablespaces option to mysqldump.
@@ -504,6 +507,10 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 
     # Skip all tables matching prefix from the exported database
     $ wp db export --exclude_tables=$(wp db tables --all-tables-with-prefix --format=csv)
+    Success: Exported to 'wordpress_dbase-db72bb5.sql'.
+
+    # Skip data of certain tables from the exported database
+    $ wp db export --exclude_tables_data=wp_actionscheduler_logs
     Success: Exported to 'wordpress_dbase-db72bb5.sql'.
 
     # Export database to STDOUT.

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -34,6 +34,8 @@ Feature: Export a WordPress database
       wp_options
       """
 
+  # Only MariaDB currently supports this feature.
+  @require-mariadb
   Scenario: Exclude data of certain tables when exporting the database
     Given a WP install
 

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -34,6 +34,16 @@ Feature: Export a WordPress database
       wp_options
       """
 
+  Scenario: Exclude data of certain tables when exporting the database
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql --exclude_tables_data=wp_actionscheduler_logs --porcelain`
+    Then the wp_cli_test.sql file should exist
+    And the wp_cli_test.sql file should contain:
+      """
+      wp_actionscheduler_logs
+      """
+
   Scenario: Export database to STDOUT
     Given a WP install
 

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -37,11 +37,15 @@ Feature: Export a WordPress database
   Scenario: Exclude data of certain tables when exporting the database
     Given a WP install
 
-    When I run `wp db export wp_cli_test.sql --exclude_tables_data=wp_actionscheduler_logs --porcelain`
+    When I run `wp db export wp_cli_test.sql --exclude_tables_data=wp_users --porcelain`
     Then the wp_cli_test.sql file should exist
     And the wp_cli_test.sql file should contain:
       """
-      wp_actionscheduler_logs
+      wp_users
+      """
+    And the wp_cli_test.sql file should not contain:
+      """
+      INSERT INTO `wp_users`
       """
 
   Scenario: Export database to STDOUT

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -70,6 +70,17 @@ Feature: Export a WordPress database
       PRAGMA foreign_keys=OFF
       """
 
+  @skip-mariadb @skip-sqlite
+  Scenario: Exclude data of certain tables is not supported by MySQL
+    Given a WP install
+
+    When I try `wp db export wp_cli_test.sql --exclude_tables_data=wp_users`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: The --exclude_tables_data option is only supported by MariaDB.
+      """
+
   # Only MariaDB currently supports this feature.
   @require-mariadb
   Scenario: Exclude data of certain tables when exporting the database

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -567,6 +567,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--exclude_tables=<tables>]
 	 * : The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database.
 	 *
+	 * [--exclude_tables_data=<tables>]
+	 * : The comma separated list of specific tables for which only the structure will be exported. Excluding this parameter will export data for all tables in the export.
+	 *
 	 * [--include-tablespaces]
 	 * : Skips adding the default --no-tablespaces option to mysqldump.
 	 *
@@ -615,6 +618,10 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 *     # Skip all tables matching prefix from the exported database
 	 *     $ wp db export --exclude_tables=$(wp db tables --all-tables-with-prefix --format=csv)
+	 *     Success: Exported to 'wordpress_dbase-db72bb5.sql'.
+	 *
+	 *     # Skip data of certain tables from the exported database
+	 *     $ wp db export --exclude_tables_data=wp_actionscheduler_logs
 	 *     Success: Exported to 'wordpress_dbase-db72bb5.sql'.
 	 *
 	 *     # Export database to STDOUT.
@@ -703,6 +710,17 @@ class DB_Command extends WP_CLI_Command {
 			unset( $assoc_args['exclude_tables'] );
 			foreach ( $tables as $table ) {
 				$command           .= ' --ignore-table';
+				$command           .= ' %s';
+				$command_esc_args[] = trim( DB_NAME . '.' . $table );
+			}
+		}
+
+		$exclude_tables_data = Utils\get_flag_value( $assoc_args, 'exclude_tables_data' );
+		if ( isset( $exclude_tables_data ) ) {
+			$tables = explode( ',', trim( $assoc_args['exclude_tables_data'], ',' ) );
+			unset( $assoc_args['exclude_tables_data'] );
+			foreach ( $tables as $table ) {
+				$command           .= ' --ignore-table-data';
 				$command           .= ' %s';
 				$command_esc_args[] = trim( DB_NAME . '.' . $table );
 			}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -569,6 +569,7 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--exclude_tables_data=<tables>]
 	 * : The comma separated list of specific tables for which only the structure will be exported. Excluding this parameter will export data for all tables in the export.
+	 *   Note: currently only supported by MariaDB.
 	 *
 	 * [--include-tablespaces]
 	 * : Skips adding the default --no-tablespaces option to mysqldump.

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -814,6 +814,8 @@ class DB_Command extends WP_CLI_Command {
 
 		$exclude_tables_data = Utils\get_flag_value( $assoc_args, 'exclude_tables_data', '' );
 		if ( ! empty( $exclude_tables_data ) ) {
+			unset( $assoc_args['exclude_tables_data'] );
+
 			if ( 'mariadb' !== Utils\get_db_type() ) {
 				WP_CLI::error( 'The --exclude_tables_data option is only supported by MariaDB.' );
 			}

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -812,24 +812,21 @@ class DB_Command extends WP_CLI_Command {
 			}
 		}
 
-		$exclude_tables_data = Utils\get_flag_value( $assoc_args, 'exclude_tables_data' );
-		if ( isset( $exclude_tables_data ) ) {
-			unset( $assoc_args['exclude_tables_data'] );
-			if ( is_string( $exclude_tables_data ) && '' !== trim( $exclude_tables_data ) ) {
-				if ( 'mariadb' !== Utils\get_db_type() ) {
-					WP_CLI::error( 'The --exclude_tables_data option is only supported by MariaDB.' );
-				}
+		$exclude_tables_data = Utils\get_flag_value( $assoc_args, 'exclude_tables_data', '' );
+		if ( ! empty( $exclude_tables_data ) ) {
+			if ( 'mariadb' !== Utils\get_db_type() ) {
+				WP_CLI::error( 'The --exclude_tables_data option is only supported by MariaDB.' );
+			}
 
-				$tables = explode( ',', trim( $exclude_tables_data, ',' ) );
-				foreach ( $tables as $table ) {
-					$table = trim( $table );
-					if ( '' === $table ) {
-						continue;
-					}
-					$command           .= ' --ignore-table-data';
-					$command           .= ' %s';
-					$command_esc_args[] = DB_NAME . '.' . $table;
+			$tables = explode( ',', trim( $exclude_tables_data, ',' ) );
+			foreach ( $tables as $table ) {
+				$table = trim( $table );
+				if ( '' === $table ) {
+					continue;
 				}
+				$command           .= ' --ignore-table-data';
+				$command           .= ' %s';
+				$command_esc_args[] = DB_NAME . '.' . $table;
 			}
 		}
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -737,12 +737,22 @@ class DB_Command extends WP_CLI_Command {
 
 		$exclude_tables_data = Utils\get_flag_value( $assoc_args, 'exclude_tables_data' );
 		if ( isset( $exclude_tables_data ) ) {
-			$tables = explode( ',', trim( $assoc_args['exclude_tables_data'], ',' ) );
 			unset( $assoc_args['exclude_tables_data'] );
-			foreach ( $tables as $table ) {
-				$command           .= ' --ignore-table-data';
-				$command           .= ' %s';
-				$command_esc_args[] = trim( DB_NAME . '.' . $table );
+			if ( is_string( $exclude_tables_data ) && '' !== trim( $exclude_tables_data ) ) {
+				if ( 'mariadb' !== Utils\get_db_type() ) {
+					WP_CLI::error( 'The --exclude_tables_data option is only supported by MariaDB.' );
+				}
+
+				$tables = explode( ',', trim( $exclude_tables_data, ',' ) );
+				foreach ( $tables as $table ) {
+					$table = trim( $table );
+					if ( '' === $table ) {
+						continue;
+					}
+					$command           .= ' --ignore-table-data';
+					$command           .= ' %s';
+					$command_esc_args[] = DB_NAME . '.' . $table;
+				}
 			}
 		}
 


### PR DESCRIPTION
Introduces the `--exclude_tables_data` option to the `wp db export` command, allowing users to export only the structure of specified tables while excluding their data.

Warning: only supported by MariaDB 10.1 and later. As far as I know, not supported by MySQL.

Resolves https://github.com/wp-cli/db-command/issues/289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--exclude_tables_data=<tables>` option to `wp db export`.
  * Export table structures without including data for selected tables.
  * Added support for MariaDB, including examples and validation for unsupported MySQL and SQLite usage.
* **Documentation**
  * Updated database export documentation with option details and usage examples.
* **Tests**
  * Added coverage for successful MariaDB exports and expected failures on MySQL and SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->