### PR TITLE
Fix: REPLACE() string function misidentified as write query

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -538,7 +538,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $this->get_sql_mode_query( $assoc_args ) . $assoc_args['execute'];
 		}
 
-		$is_row_modifying_query = isset( $assoc_args['execute'] ) && preg_match( '/\b(UPDATE|DELETE|INSERT|REPLACE|LOAD DATA)\b/i', $assoc_args['execute'] );
+		$is_row_modifying_query = isset( $assoc_args['execute'] ) && preg_match( '/\b(UPDATE|DELETE|INSERT|REPLACE(?!\s*\()|LOAD DATA)\b/i', $assoc_args['execute'] );
 
 		if ( $is_row_modifying_query ) {
 			$assoc_args['execute'] .= '; SELECT ROW_COUNT();';


### PR DESCRIPTION
Fixes #313

## Description

`wp db query` silently swallows SELECT results when the query contains the MySQL `REPLACE()` string function. The command outputs `Success: Query succeeded. Rows affected: -1` instead of the actual query results.

The write-query detection regex added in #277 matches bare `REPLACE` without distinguishing between:
- `REPLACE()` — a MySQL string function used in SELECT statements
- `REPLACE INTO` / `REPLACE` — a DML write statement

## Change

One-line regex fix — adds a negative lookahead `(?!\s*\()` so that `REPLACE` only matches when it's **not** followed by an opening parenthesis:

```php
// Before
'/\b(UPDATE|DELETE|INSERT|REPLACE|LOAD DATA)\b/i'

// After
'/\b(UPDATE|DELETE|INSERT|REPLACE(?!\s*\()|LOAD DATA)\b/i'
```

## Testing

Tested against a live WordPress multisite (WP 6.9.1, MariaDB, PHP 8.4) by extracting the 2.12.0 phar, patching DB_Command.php, and running from source. Full results:

**SELECT queries with REPLACE() — all correctly return results:**

| Test | Result |
|------|--------|
| `SELECT REPLACE('hello world', 'world', 'there')` | ✅ `hello there` |
| REPLACE in WHERE clause | ✅ |
| REPLACE in JOIN condition | ✅ |
| Triple-nested `REPLACE(REPLACE(REPLACE(...)))` | ✅ |
| REPLACE mixed with UPPER() + TRIM() | ✅ |
| REPLACE inside CASE expression | ✅ |
| REPLACE in subquery | ✅ |
| REPLACE in GROUP BY + ORDER BY | ✅ |
| REPLACE on real WordPress data | ✅ |

**Write queries — all correctly show rows affected:**

| Test | Result |
|------|--------|
| INSERT INTO | ✅ Rows affected: 1 |
| UPDATE containing REPLACE() in SET | ✅ Rows affected: 1 |
| DELETE | ✅ Rows affected: 1 |
| REPLACE INTO (DML write) | ✅ Rows affected: 1 |
| REPLACE INTO upsert | ✅ Rows affected: 2 |
| Bare REPLACE without INTO (valid MySQL) | ✅ Rows affected: 1 |
| UPDATE with nested REPLACE(REPLACE()) | ✅ Rows affected: 1 |
| LOAD DATA (regex only) | ✅ Match |

The negative lookahead handles every combination — including the rare bare `REPLACE table (...)` syntax (without INTO) which MySQL/MariaDB accept as valid DML.

## Discovery Context

Found this bug while running automated audit queries against a WordPress multisite events calendar — using `REPLACE()` to strip suffixes from taxonomy term names for comparison. The query returned nothing, forcing a workaround through `wp db cli` piping.

- [x] Yes, I reviewed the [contribution guidelines](https://make.wordpress.org/cli/handbook/contributing/).

---

**AI disclosure:** This PR was prepared with AI assistance (Claude Code). The diagnosis, fix, and tests were reviewed and validated by the submitter against a live WordPress multisite (WP 6.9.1, MariaDB 10.11, PHP 8.4).
