### PR TITLE
Specify scope options in same format as other arguments that have a list

### DIFF
--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -958,14 +958,20 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--scope=<scope>]
 	 * : List tables based on the scope.
+	 *
+	 * - all: returns 'all' and 'global' tables. No old tables are returned.
+	 * - blog: returns the blog-level tables for the queried blog.
+	 * - global: returns the global tables for the installation, returning multisite tables only on multisite.
+	 * - ms_global: returns the multisite global tables, regardless if current installation is multisite.
+	 * - old: returns tables which are deprecated.
 	 * ---
 	 * default: all
 	 * options:
-	 *   - all       - returns 'all' and 'global' tables. No old tables are returned.
-	 *   - blog      - returns the blog-level tables for the queried blog.
-	 *   - global    - returns the global tables for the installation, returning multisite tables only on multisite.
-	 *   - ms_global - returns the multisite global tables, regardless if current installation is multisite.
-	 *   - old       - returns tables which are deprecated.
+	 *   - all
+	 *   - blog
+	 *   - global
+	 *   - ms_global
+	 *   - old
 	 * ---
 	 *
 	 * [--network]

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -957,7 +957,16 @@ class DB_Command extends WP_CLI_Command {
 	 * : List tables based on wildcard search, e.g. 'wp_*_options' or 'wp_post?'.
 	 *
 	 * [--scope=<scope>]
-	 * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
+	 * : List tables based on the scope.
+	 * ---
+	 * default: all
+	 * options:
+	 *   - all       - returns 'all' and 'global' tables. No old tables are returned.
+	 *   - blog      - returns the blog-level tables for the queried blog.
+	 *   - global    - returns the global tables for the installation, returning multisite tables only on multisite.
+	 *   - ms_global - returns the multisite global tables, regardless if current installation is multisite.
+	 *   - old       - returns tables which are deprecated.
+	 * ---
 	 *
 	 * [--network]
 	 * : List all the tables in a multisite install.


### PR DESCRIPTION
The current format was a bit confusing to me, what did "old" do? Was I it maybe a typo "old_tables"?
Found out there was a more conventional formatting listed options.

Based on the documentation of [wpdb->tables()](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wpdb.php#L1099-L1103).

Nowhere in the current codebase is there a list of options, that is then further clarified per option.
So I just did put in this format as "readable". I think the extra explanation is valuable in this case, as options aren't clear by themselves.

**Point of discussion.**
Is there a better way of doing the extra clarification, will this break auto documentation?
If there is a better way please point me to an example and I will follow it.