### PR TITLE
db export: Avoid exec() in option probe

### DIFF
--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -147,3 +147,16 @@ Feature: Export a WordPress database
 
     When I try `wp db export --no-defaults --debug`
     Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump) --no-defaults#
+
+  @skip-sqlite
+  @skip-windows
+  Scenario: Export database when PHP exec() is disabled
+    Given a WP install
+
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=exec} db export wp_cli_test.sql --porcelain`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      wp_cli_test.sql
+      """
+    And the wp_cli_test.sql file should exist

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_CLI\Formatter;
+use WP_CLI\Process;
 use WP_CLI\Utils;
 use cli\table\Column;
 
@@ -867,30 +868,9 @@ class DB_Command extends WP_CLI_Command {
 	 * @return bool Whether the option is listed in help output.
 	 */
 	private function command_supports_option( $command, $option ) {
-		Utils\check_proc_available( __METHOD__ );
+		$result = Process::create( "{$command} --help" )->run();
 
-		$descriptors = [
-			0 => STDIN,
-			1 => [ 'pipe', 'w' ],
-			2 => [ 'pipe', 'w' ],
-		];
-		$pipes       = [];
-		$process     = Utils\proc_open_compat( "{$command} --help", $descriptors, $pipes );
-
-		if ( ! $process ) {
-			WP_CLI::debug( "Failed to inspect help output for command: {$command}", 'db' );
-			return false;
-		}
-
-		$stdout = stream_get_contents( $pipes[1] );
-		$stderr = stream_get_contents( $pipes[2] );
-
-		fclose( $pipes[1] );
-		fclose( $pipes[2] );
-
-		proc_close( $process );
-
-		return false !== strpos( $stdout . $stderr, $option );
+		return false !== strpos( $result->stdout . $result->stderr, $option );
 	}
 
 	/**

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -747,7 +747,7 @@ class DB_Command extends WP_CLI_Command {
 
 		$mysqldump_binary = Utils\force_env_on_nix_systems( Utils\get_sql_dump_command() );
 
-		$support_column_statistics = exec( $mysqldump_binary . ' --help | grep "column-statistics"' );
+		$support_column_statistics = $this->command_supports_option( $mysqldump_binary, 'column-statistics' );
 
 		/*
 		 * In case that `--default-character-set` is not given and `DB_CHARSET` is `utf8`,
@@ -857,6 +857,40 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI::debug( "Detected character set of the posts table: {$stdout}.", 'db' );
 
 		return $stdout;
+	}
+
+	/**
+	 * Check whether a shell command advertises support for a specific option in `--help`.
+	 *
+	 * @param string $command Base shell command to inspect.
+	 * @param string $option  Option name to look for.
+	 * @return bool Whether the option is listed in help output.
+	 */
+	private function command_supports_option( $command, $option ) {
+		Utils\check_proc_available( __METHOD__ );
+
+		$descriptors = [
+			0 => STDIN,
+			1 => [ 'pipe', 'w' ],
+			2 => [ 'pipe', 'w' ],
+		];
+		$pipes       = [];
+		$process     = Utils\proc_open_compat( "{$command} --help", $descriptors, $pipes );
+
+		if ( ! $process ) {
+			WP_CLI::debug( "Failed to inspect help output for command: {$command}", 'db' );
+			return false;
+		}
+
+		$stdout = stream_get_contents( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
+
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+
+		proc_close( $process );
+
+		return false !== strpos( $stdout . $stderr, $option );
 	}
 
 	/**


### PR DESCRIPTION
As described in #283, if the host disables the `exec()` function, `db export` will fail silently with exit code 255.

This works around that that by using `Utils\proc_open_compat()`.