### PR TITLE
Add mysqldump flags docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] 
 **Alias:** `dump`
 
 Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
-`DB_PASSWORD` database credentials specified in wp-config.php. Accepts any valid `mysqldump` flags.
+`DB_PASSWORD` database credentials specified in wp-config.php. Accepts any valid [`mysqldump` flags](https://dev.mysql.com/doc/en/mysqldump.html#mysqldump-option-summary).
 
 **OPTIONS**
 

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -636,7 +636,7 @@ class DB_Command extends WP_CLI_Command {
 	 * Exports the database to a file or to STDOUT.
 	 *
 	 * Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
-	 * `DB_PASSWORD` database credentials specified in wp-config.php. Accepts any valid `mysqldump` flags.
+	 * `DB_PASSWORD` database credentials specified in wp-config.php. Accepts any valid [`mysqldump` flags](https://dev.mysql.com/doc/en/mysqldump.html#mysqldump-option-summary).
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
## Summary
- Link the `mysqldump` flags mention in the `wp db export` docs to the MySQL option summary.
- Keep the generated README in sync with the command docblock.

## Testing
- `git diff --check`
