### PR TITLE
Fix SQL mode compat issues by removing the additional probe request

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -247,3 +247,95 @@ Feature: Import a WordPress database
       """
       🍣
       """
+
+  # SQLite does not use the MySQL client and has no concept of SQL modes.
+  @require-mysql-or-mariadb
+  Scenario: `wp db import` adapts the SQL mode in-band by default
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    # The WordPress-compatibility mode adaptation is applied via the MySQL client's
+    # --init-command on the same connection, so it is visible in the debug output
+    # and no separate mode probe runs (which is what used to break with custom
+    # connection options).
+    When I try `wp db import wp_cli_test.sql --debug`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      SET SESSION sql_mode
+      """
+    And STDERR should not contain:
+      """
+      Failed to get current SQL modes
+      """
+
+  @require-mysql-or-mariadb
+  Scenario: `wp db import --skip-sql-mode-compat` imports under the server's own SQL modes
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I try `wp db import wp_cli_test.sql --skip-sql-mode-compat --debug`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      SET SESSION sql_mode
+      """
+
+  # Regression test for the WordPress-compatibility behavior. WordPress schema
+  # declares datetime columns as `DEFAULT '0000-00-00 00:00:00'`, so real dumps
+  # carry zero-date values. On servers whose default SQL mode includes
+  # NO_ZERO_DATE/STRICT_TRANS_TABLES (MySQL 5.7+/8.0), a raw dump without its own
+  # SQL_MODE header would fail to import with "Invalid default value". `wp db
+  # import` must strip those modes for the session so the import succeeds.
+  @require-mysql-or-mariadb
+  Scenario: `wp db import` loads a dump containing legacy zero-date values
+    Given a WP install
+    And a zerodate.sql file:
+      """
+      CREATE TABLE `wp_cli_zerodate` (
+        `id` int NOT NULL,
+        `d` datetime NOT NULL DEFAULT '0000-00-00 00:00:00'
+      );
+      INSERT INTO `wp_cli_zerodate` (`id`, `d`) VALUES (1, '0000-00-00 00:00:00');
+      """
+
+    When I run `wp db import zerodate.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'zerodate.sql'.
+      """
+
+    When I run `wp db query 'SELECT COUNT(*) FROM wp_cli_zerodate;' --skip-column-names`
+    Then STDOUT should contain:
+      """
+      1
+      """
+
+  # Regression test for https://github.com/wp-cli/db-command/issues/171
+  # A dump streamed from STDIN must get the same WordPress SQL-mode compatibility
+  # as a file import. This is now handled via --init-command, which applies on the
+  # STDIN connection too (the previous prepend only covered file imports).
+  @require-mysql-or-mariadb
+  Scenario: `wp db import -` from STDIN loads a dump containing legacy zero-date values
+    Given a WP install
+    And a zerodate_stdin.sql file:
+      """
+      CREATE TABLE wp_cli_zerodate_stdin (id int NOT NULL, d datetime NOT NULL DEFAULT '0000-00-00 00:00:00');
+      INSERT INTO wp_cli_zerodate_stdin (id, d) VALUES (1, '0000-00-00 00:00:00');
+      """
+
+    When I run `wp db import - < zerodate_stdin.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'STDIN'.
+      """
+
+    When I run `wp db query 'SELECT COUNT(*) FROM wp_cli_zerodate_stdin;' --skip-column-names`
+    Then STDOUT should contain:
+      """
+      1
+      """

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -250,16 +250,16 @@ Feature: Import a WordPress database
 
   # SQLite does not use the MySQL client and has no concept of SQL modes.
   @require-mysql-or-mariadb
-  Scenario: `wp db import` adapts the SQL mode in-band by default
+  Scenario: `wp db import` adapts the SQL mode via --init-command by default
     Given a WP install
 
     When I run `wp db export wp_cli_test.sql`
     Then the wp_cli_test.sql file should exist
 
     # The WordPress-compatibility mode adaptation runs on the same import
-    # connection (prepended to the executed statement for a file import), so it is
-    # visible in the debug output and no separate mode probe runs (which is what
-    # used to break with custom connection options).
+    # connection via --init-command, so it is visible in the debug output and no
+    # separate mode probe runs (which is what used to break with custom connection
+    # options).
     When I try `wp db import wp_cli_test.sql --debug`
     Then the return code should be 0
     And STDERR should contain:
@@ -341,7 +341,8 @@ Feature: Import a WordPress database
       """
 
   # The compatibility statement must compose with a caller-supplied --init-command
-  # rather than replace it. A file import prepends it to the executed batch, so the
+  # rather than replace it. Both are sent as a single multi-statement
+  # --init-command (compatibility statement first, caller's second), so the
   # caller's own init command still runs and the zero-date import still succeeds.
   @require-mysql-or-mariadb
   Scenario: `wp db import` keeps SQL-mode compatibility when the caller sets --init-command

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -256,10 +256,10 @@ Feature: Import a WordPress database
     When I run `wp db export wp_cli_test.sql`
     Then the wp_cli_test.sql file should exist
 
-    # The WordPress-compatibility mode adaptation is applied via the MySQL client's
-    # --init-command on the same connection, so it is visible in the debug output
-    # and no separate mode probe runs (which is what used to break with custom
-    # connection options).
+    # The WordPress-compatibility mode adaptation runs on the same import
+    # connection (prepended to the executed statement for a file import), so it is
+    # visible in the debug output and no separate mode probe runs (which is what
+    # used to break with custom connection options).
     When I try `wp db import wp_cli_test.sql --debug`
     Then the return code should be 0
     And STDERR should contain:
@@ -338,4 +338,22 @@ Feature: Import a WordPress database
     Then STDOUT should contain:
       """
       1
+      """
+
+  # The compatibility statement must compose with a caller-supplied --init-command
+  # rather than replace it. A file import prepends it to the executed batch, so the
+  # caller's own init command still runs and the zero-date import still succeeds.
+  @require-mysql-or-mariadb
+  Scenario: `wp db import` keeps SQL-mode compatibility when the caller sets --init-command
+    Given a WP install
+    And a zerodate_compose.sql file:
+      """
+      CREATE TABLE wp_cli_zd_compose (id int NOT NULL, d datetime NOT NULL DEFAULT '0000-00-00 00:00:00');
+      INSERT INTO wp_cli_zd_compose (id, d) VALUES (1, '0000-00-00 00:00:00');
+      """
+
+    When I run `wp db import zerodate_compose.sql --init-command="SET @x = 1"`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'zerodate_compose.sql'.
       """

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -91,33 +91,41 @@ Feature: Query the database with WordPress' MySQL config
     When I try `wp db query --no-defaults --debug`
     Then STDERR should match #Debug \(db\): Running shell command: /([^/]+/)+(mysql|mariadb) --no-defaults --no-auto-rehash#
 
-  Scenario: SQL modes do not include any of the modes incompatible with WordPress
+  Scenario: `wp db query` runs under the server's own SQL modes without a separate mode probe
     Given a WP install
 
-    When I try `wp db query 'SELECT @@SESSION.sql_mode;' --debug`
-    Then STDOUT should not contain:
+    # The previous implementation always opened a second `SELECT @@SESSION.sql_mode`
+    # connection to decide whether to rewrite the query, then prepended a
+    # `SET SESSION sql_mode=...` statement. Both are gone: `wp db query` now behaves
+    # like the `mysql` client and runs under the server's own SQL modes.
+    When I try `wp db query 'SELECT 1;' --debug`
+    Then the return code should be 0
+    And STDERR should not contain:
       """
-      NO_ZERO_DATE
+      @@SESSION.sql_mode
       """
-    And STDOUT should not contain:
+    And STDERR should not contain:
       """
-      ONLY_FULL_GROUP_BY
+      SET SESSION sql_mode
       """
-    And STDOUT should not contain:
+
+  # Regression test for https://github.com/wp-cli/db-command/issues/311
+  # Passing connection options alongside an inline query used to fail, because the
+  # SQL-mode probe opened a *second* connection that ignored those very options
+  # (custom --host, --defaults, SSL/TLS, sockets, ...) and then aborted the whole
+  # command with "Failed to get current SQL modes". With the probe removed, the
+  # inline query runs directly under the given options.
+  Scenario: `wp db query` with an inline query and connection options does not trigger a failing mode probe
+    Given a WP install
+
+    When I try `wp db query 'SELECT 1;' --defaults --debug`
+    Then STDERR should not contain:
       """
-      STRICT_TRANS_TABLES
+      Failed to get current SQL modes
       """
-    And STDOUT should not contain:
+    And STDERR should not contain:
       """
-      STRICT_ALL_TABLES
-      """
-    And STDOUT should not contain:
-      """
-      TRADITIONAL
-      """
-    And STDOUT should not contain:
-      """
-      ANSI
+      @@SESSION.sql_mode
       """
 
   # Regression test for https://github.com/wp-cli/db-command/issues/309

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -91,19 +91,32 @@ Feature: Query the database with WordPress' MySQL config
     When I try `wp db query --no-defaults --debug`
     Then STDERR should match #Debug \(db\): Running shell command: /([^/]+/)+(mysql|mariadb) --no-defaults --no-auto-rehash#
 
-  Scenario: `wp db query` runs under the server's own SQL modes without a separate mode probe
+  # `wp db query` adapts the session SQL mode to be WordPress-compatible the same
+  # way `wp db import` does: via --init-command on the query's own connection, with
+  # no separate mode probe. This keeps statements against WordPress's zero-date
+  # schema (e.g. `ALTER TABLE wp_blogs ...`, `CREATE TABLE ... AS SELECT` from a
+  # WordPress table) working on servers whose default SQL mode is strict.
+  @require-mysql-or-mariadb
+  Scenario: `wp db query` adapts the SQL mode by default without a separate mode probe
     Given a WP install
 
-    # The previous implementation always opened a second `SELECT @@SESSION.sql_mode`
-    # connection to decide whether to rewrite the query, then prepended a
-    # `SET SESSION sql_mode=...` statement. Both are gone: `wp db query` now behaves
-    # like the `mysql` client and runs under the server's own SQL modes.
     When I try `wp db query 'SELECT 1;' --debug`
     Then the return code should be 0
+    And STDERR should contain:
+      """
+      SET SESSION sql_mode
+      """
     And STDERR should not contain:
       """
-      @@SESSION.sql_mode
+      Failed to get current SQL modes
       """
+
+  @require-mysql-or-mariadb
+  Scenario: `wp db query --skip-sql-mode-compat` runs under the server's own SQL modes
+    Given a WP install
+
+    When I try `wp db query 'SELECT 1;' --skip-sql-mode-compat --debug`
+    Then the return code should be 0
     And STDERR should not contain:
       """
       SET SESSION sql_mode
@@ -111,10 +124,11 @@ Feature: Query the database with WordPress' MySQL config
 
   # Regression test for https://github.com/wp-cli/db-command/issues/311
   # Passing connection options alongside an inline query used to fail, because the
-  # SQL-mode probe opened a *second* connection that ignored those very options
+  # old SQL-mode probe opened a *second* connection that ignored those very options
   # (custom --host, --defaults, SSL/TLS, sockets, ...) and then aborted the whole
-  # command with "Failed to get current SQL modes". With the probe removed, the
-  # inline query runs directly under the given options.
+  # command with "Failed to get current SQL modes". The probe is gone -- the
+  # compatibility mode is now applied via --init-command on the query's own
+  # connection -- so the inline query runs directly under the given options.
   Scenario: `wp db query` with an inline query and connection options does not trigger a failing mode probe
     Given a WP install
 
@@ -122,10 +136,6 @@ Feature: Query the database with WordPress' MySQL config
     Then STDERR should not contain:
       """
       Failed to get current SQL modes
-      """
-    And STDERR should not contain:
-      """
-      @@SESSION.sql_mode
       """
 
   # Regression test for https://github.com/wp-cli/db-command/issues/309

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -606,11 +606,8 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		if ( isset( $assoc_args['execute'] ) ) {
-			// Ensure that the SQL mode is compatible with WPDB.
-			$assoc_args['execute'] = $this->get_sql_mode_query( $assoc_args ) . $assoc_args['execute'];
-		}
-
+		// Note: `wp db query` intentionally runs under the server's own SQL modes,
+		// like the `mysql` client itself. No SQL-mode adaptation is applied here.
 		$is_row_modifying_query = isset( $assoc_args['execute'] ) && preg_match( '/\b(UPDATE|DELETE|INSERT|REPLACE(?!\s*\()|LOAD DATA)\b/i', $assoc_args['execute'] );
 
 		if ( $is_row_modifying_query ) {
@@ -898,6 +895,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--skip-optimization]
 	 * : When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
 	 *
+	 * [--skip-sql-mode-compat]
+	 * : Do not adapt the session SQL mode for WordPress compatibility. By default, `wp db import` strips the SQL modes that WordPress Core disables (such as `STRICT_TRANS_TABLES` and `NO_ZERO_DATE`) so that dumps containing legacy values like `0000-00-00` import cleanly. Pass this flag to import under the server's own SQL modes instead.
+	 *
 	 * [--defaults]
 	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
@@ -928,6 +928,14 @@ class DB_Command extends WP_CLI_Command {
 			self::get_mysql_args( $assoc_args )
 		);
 
+		// Adapt the session SQL mode to be WordPress-compatible via --init-command,
+		// so it runs on connect before any SQL is read. This covers both file and
+		// STDIN imports, and needs no separate probe connection.
+		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
+		if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
+			$mysql_args['init-command'] = $sql_mode_compat;
+		}
+
 		if ( '-' !== $result_file ) {
 			if ( ! is_readable( $result_file ) ) {
 				WP_CLI::error( sprintf( 'Import file missing or not readable: %s', $result_file ) );
@@ -936,8 +944,6 @@ class DB_Command extends WP_CLI_Command {
 			$query = Utils\get_flag_value( $assoc_args, 'skip-optimization' )
 				? 'SOURCE %s;'
 				: 'SET autocommit = 0; SET unique_checks = 0; SET foreign_key_checks = 0; SOURCE %s; COMMIT;';
-
-			$query = $this->get_sql_mode_query( $assoc_args ) . $query;
 
 			$mysql_args['execute'] = sprintf( $query, $result_file );
 		} else {
@@ -1926,15 +1932,19 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array  $assoc_args Optional. Associative array of arguments.
 	 */
 	protected function run_query( $query, $assoc_args = [] ) {
-		// Ensure that the SQL mode is compatible with WPDB.
-		$query = $this->get_sql_mode_query( $assoc_args ) . $query;
-
 		WP_CLI::debug( "Query: {$query}", 'db' );
 
 		$mysql_args = array_merge(
 			self::get_dbuser_dbpass_args( $assoc_args ),
 			self::get_mysql_args( $assoc_args )
 		);
+
+		// Adapt the session SQL mode to be WordPress-compatible via --init-command
+		// (runs on connect, needs no separate probe connection).
+		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
+		if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
+			$mysql_args['init-command'] = $sql_mode_compat;
+		}
 
 		self::run(
 			sprintf(
@@ -2304,103 +2314,38 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the query to change the current SQL mode, and ensure its WordPress compatibility.
+	 * Get the statement that strips the SQL modes incompatible with WordPress
+	 * from the current session.
 	 *
-	 * If no modes are passed, it will ensure the current MySQL server modes are
-	 * compatible.
+	 * This is handed to the MySQL client as `--init-command`, so it runs on the
+	 * very same connection right after connecting and before any SQL is read.
+	 * Imports therefore behave like WordPress Core (which disables these modes in
+	 * `wpdb`), including when the dump is streamed from STDIN. Unlike the previous
+	 * implementation, no separate connection is opened to first discover the
+	 * current modes, so it works regardless of the connection options in play
+	 * (custom `--host`, `--defaults`, SSL/TLS, sockets, ...).
 	 *
-	 * Copied and adapted from WordPress Core code.
+	 * Returns an empty string when the `--skip-sql-mode-compat` flag is set.
 	 *
-	 * @see https://github.com/WordPress/wordpress-develop/blob/5.4.0/src/wp-includes/wp-db.php#L817-L880
+	 * @see https://github.com/WordPress/wordpress-develop/blob/5.4.0/src/wp-includes/wp-db.php#L559-L572
 	 *
 	 * @param array $assoc_args The associative argument array passed to the command.
-	 * @param array $modes      Optional. A list of SQL modes to set.
-	 * @return string Query string to use for setting the SQL modes to a
-	 *                compatible state.
+	 * @return string SQL statement to run via `--init-command`, or an empty string.
 	 */
-	protected function get_sql_mode_query( $assoc_args, $modes = [] ) {
-		if ( empty( $modes ) ) {
-			$modes = $this->get_current_sql_modes( $assoc_args );
-		}
-
-		$modes = array_change_key_case( $modes, CASE_UPPER );
-
-		$is_mode_adaptation_needed = false;
-		foreach ( $modes as $i => $mode ) {
-			if ( in_array( $mode, $this->sql_incompatible_modes, true ) ) {
-				unset( $modes[ $i ] );
-				$is_mode_adaptation_needed = true;
-			}
-		}
-
-		if ( ! $is_mode_adaptation_needed ) {
-			WP_CLI::debug(
-				sprintf(
-					'SQL modes look fine: %s',
-					json_encode( $modes )
-				)
-			);
+	protected function get_sql_mode_compat_statement( $assoc_args = [] ) {
+		if ( Utils\get_flag_value( $assoc_args, 'skip-sql-mode-compat', false ) ) {
 			return '';
 		}
 
-		WP_CLI::debug(
-			sprintf(
-				'SQL mode adaptation is needed: %s => %s',
-				json_encode( $this->get_current_sql_modes( $assoc_args ) ),
-				json_encode( $modes )
-			)
-		);
-
-		$modes_str = implode( ',', $modes );
-
-		return "SET SESSION sql_mode='{$modes_str}';";
-	}
-
-	/**
-	 * Get the list of current SQL modes.
-	 *
-	 * @param array $assoc_args The associative argument array passed to the command.
-	 * @return string[] Array of SQL modes.
-	 */
-	protected function get_current_sql_modes( $assoc_args ) {
-		static $modes = null;
-
-		// Make sure the provided arguments don't interfere with the expected
-		// output here.
-		$args = [];
-
-		if ( null === $modes ) {
-			$modes = [];
-
-			list( $stdout, $stderr, $exit_code ) = self::run(
-				sprintf(
-					'%s%s --no-auto-rehash --batch --skip-column-names',
-					Utils\get_mysql_binary_path(),
-					$this->get_defaults_flag_string( $assoc_args )
-				),
-				array_merge( $args, [ 'execute' => 'SELECT @@SESSION.sql_mode' ] ),
-				false
-			);
-
-			if ( $exit_code ) {
-				WP_CLI::error(
-					'Failed to get current SQL modes.'
-					. ( ! empty( $stderr ) ? " Reason: {$stderr}" : '' ),
-					$exit_code
-				);
-			}
-
-			if ( ! empty( $stdout ) ) {
-				$lines = preg_split( "/\r\n|\n|\r|,/", $stdout );
-				$modes = array_filter(
-					array_map(
-						'trim',
-						$lines ? $lines : []
-					)
-				);
-			}
+		// Strip the incompatible modes from the session mode list. Each mode is
+		// wrapped in commas so that it only matches as a whole token and never as
+		// a substring -- stripping `ANSI` must not turn `ANSI_QUOTES` into
+		// `_QUOTES`, for example.
+		$expression = "CONCAT( ',', @@SESSION.sql_mode, ',' )";
+		foreach ( $this->sql_incompatible_modes as $mode ) {
+			$expression = sprintf( "REPLACE( %s, ',%s,', ',' )", $expression, $mode );
 		}
 
-		return $modes;
+		return sprintf( "SET SESSION sql_mode = TRIM( BOTH ',' FROM %s )", $expression );
 	}
 }

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -928,13 +928,12 @@ class DB_Command extends WP_CLI_Command {
 			self::get_mysql_args( $assoc_args )
 		);
 
-		// Adapt the session SQL mode to be WordPress-compatible via --init-command,
-		// so it runs on connect before any SQL is read. This covers both file and
-		// STDIN imports, and needs no separate probe connection.
+		// Adapt the session SQL mode to be WordPress-compatible. When there is an
+		// --execute batch (importing from a file), prepend it there so it composes
+		// with any init command the caller already set (via --init-command or an
+		// option file). When importing from STDIN there is no --execute, so apply
+		// it via --init-command instead. Either way, no separate probe connection.
 		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
-		if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
-			$mysql_args['init-command'] = $sql_mode_compat;
-		}
 
 		if ( '-' !== $result_file ) {
 			if ( ! is_readable( $result_file ) ) {
@@ -945,9 +944,17 @@ class DB_Command extends WP_CLI_Command {
 				? 'SOURCE %s;'
 				: 'SET autocommit = 0; SET unique_checks = 0; SET foreign_key_checks = 0; SOURCE %s; COMMIT;';
 
+			if ( '' !== $sql_mode_compat ) {
+				$query = $sql_mode_compat . '; ' . $query;
+			}
+
 			$mysql_args['execute'] = sprintf( $query, $result_file );
 		} else {
 			$result_file = 'STDIN';
+
+			if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
+				$mysql_args['init-command'] = $sql_mode_compat;
+			}
 		}
 
 		$command = sprintf(
@@ -1932,19 +1939,20 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array  $assoc_args Optional. Associative array of arguments.
 	 */
 	protected function run_query( $query, $assoc_args = [] ) {
+		// Adapt the session SQL mode to be WordPress-compatible by prepending it to
+		// the executed batch, so it composes with any init command the caller set
+		// and needs no separate probe connection.
+		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
+		if ( '' !== $sql_mode_compat ) {
+			$query = $sql_mode_compat . '; ' . $query;
+		}
+
 		WP_CLI::debug( "Query: {$query}", 'db' );
 
 		$mysql_args = array_merge(
 			self::get_dbuser_dbpass_args( $assoc_args ),
 			self::get_mysql_args( $assoc_args )
 		);
-
-		// Adapt the session SQL mode to be WordPress-compatible via --init-command
-		// (runs on connect, needs no separate probe connection).
-		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
-		if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
-			$mysql_args['init-command'] = $sql_mode_compat;
-		}
 
 		self::run(
 			sprintf(
@@ -2317,20 +2325,22 @@ class DB_Command extends WP_CLI_Command {
 	 * Get the statement that strips the SQL modes incompatible with WordPress
 	 * from the current session.
 	 *
-	 * This is handed to the MySQL client as `--init-command`, so it runs on the
-	 * very same connection right after connecting and before any SQL is read.
-	 * Imports therefore behave like WordPress Core (which disables these modes in
-	 * `wpdb`), including when the dump is streamed from STDIN. Unlike the previous
-	 * implementation, no separate connection is opened to first discover the
-	 * current modes, so it works regardless of the connection options in play
-	 * (custom `--host`, `--defaults`, SSL/TLS, sockets, ...).
+	 * The statement is run on the same connection as the import or query -- either
+	 * prepended to the executed batch, or via `--init-command` when importing from
+	 * STDIN (where there is no executed batch). Imports therefore behave like
+	 * WordPress Core (which disables these modes in `wpdb`), including when the
+	 * dump is streamed from STDIN. Unlike the previous implementation, no separate
+	 * connection is opened to first discover the current modes, so it works
+	 * regardless of the connection options in play (custom `--host`, `--defaults`,
+	 * SSL/TLS, sockets, ...).
 	 *
 	 * Returns an empty string when the `--skip-sql-mode-compat` flag is set.
 	 *
 	 * @see https://github.com/WordPress/wordpress-develop/blob/5.4.0/src/wp-includes/wp-db.php#L559-L572
 	 *
 	 * @param array $assoc_args The associative argument array passed to the command.
-	 * @return string SQL statement to run via `--init-command`, or an empty string.
+	 * @return string SQL statement that sets a WordPress-compatible SQL mode, or an
+	 *                empty string.
 	 */
 	protected function get_sql_mode_compat_statement( $assoc_args = [] ) {
 		if ( Utils\get_flag_value( $assoc_args, 'skip-sql-mode-compat', false ) ) {

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -513,6 +513,13 @@ class DB_Command extends WP_CLI_Command {
 	 * [--defaults]
 	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
+	 * [--skip-sql-mode-compat]
+	 * : Run the query under the server's own SQL modes instead of adapting them to
+	 * be WordPress-compatible. By default, the incompatible modes that WordPress
+	 * disables in `wpdb` (such as `NO_ZERO_DATE` and `STRICT_TRANS_TABLES`) are
+	 * stripped for the session, so statements against WordPress's zero-date schema
+	 * behave the same as they do in WordPress itself.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Execute a query stored in a file
@@ -606,8 +613,14 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		// Note: `wp db query` intentionally runs under the server's own SQL modes,
-		// like the `mysql` client itself. No SQL-mode adaptation is applied here.
+		// Adapt the session SQL mode to be WordPress-compatible via --init-command,
+		// so it runs on connect before the query -- exactly like `wp db import` and
+		// WordPress Core's own wpdb -- and composes with any caller-provided
+		// --init-command. No separate probe connection is needed. Pass
+		// --skip-sql-mode-compat to run under the server's own SQL modes instead.
+		$this->apply_sql_mode_compat_init_command( $assoc_args, $assoc_args );
+		unset( $assoc_args['skip-sql-mode-compat'] );
+
 		$is_row_modifying_query = isset( $assoc_args['execute'] ) && preg_match( '/\b(UPDATE|DELETE|INSERT|REPLACE(?!\s*\()|LOAD DATA)\b/i', $assoc_args['execute'] );
 
 		if ( $is_row_modifying_query ) {
@@ -928,12 +941,11 @@ class DB_Command extends WP_CLI_Command {
 			self::get_mysql_args( $assoc_args )
 		);
 
-		// Adapt the session SQL mode to be WordPress-compatible. When there is an
-		// --execute batch (importing from a file), prepend it there so it composes
-		// with any init command the caller already set (via --init-command or an
-		// option file). When importing from STDIN there is no --execute, so apply
-		// it via --init-command instead. Either way, no separate probe connection.
-		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
+		// Adapt the session SQL mode to be WordPress-compatible via --init-command,
+		// so it runs on connect before any SQL is read. This covers both file and
+		// STDIN imports, composes with any caller-provided --init-command, and needs
+		// no separate probe connection.
+		$this->apply_sql_mode_compat_init_command( $mysql_args, $assoc_args );
 
 		if ( '-' !== $result_file ) {
 			if ( ! is_readable( $result_file ) ) {
@@ -944,17 +956,9 @@ class DB_Command extends WP_CLI_Command {
 				? 'SOURCE %s;'
 				: 'SET autocommit = 0; SET unique_checks = 0; SET foreign_key_checks = 0; SOURCE %s; COMMIT;';
 
-			if ( '' !== $sql_mode_compat ) {
-				$query = $sql_mode_compat . '; ' . $query;
-			}
-
 			$mysql_args['execute'] = sprintf( $query, $result_file );
 		} else {
 			$result_file = 'STDIN';
-
-			if ( '' !== $sql_mode_compat && ! isset( $mysql_args['init-command'] ) ) {
-				$mysql_args['init-command'] = $sql_mode_compat;
-			}
 		}
 
 		$command = sprintf(
@@ -1939,20 +1943,17 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array  $assoc_args Optional. Associative array of arguments.
 	 */
 	protected function run_query( $query, $assoc_args = [] ) {
-		// Adapt the session SQL mode to be WordPress-compatible by prepending it to
-		// the executed batch, so it composes with any init command the caller set
-		// and needs no separate probe connection.
-		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
-		if ( '' !== $sql_mode_compat ) {
-			$query = $sql_mode_compat . '; ' . $query;
-		}
-
 		WP_CLI::debug( "Query: {$query}", 'db' );
 
 		$mysql_args = array_merge(
 			self::get_dbuser_dbpass_args( $assoc_args ),
 			self::get_mysql_args( $assoc_args )
 		);
+
+		// Adapt the session SQL mode to be WordPress-compatible via --init-command,
+		// so it runs on connect before the query, composes with any caller-provided
+		// --init-command, and needs no separate probe connection.
+		$this->apply_sql_mode_compat_init_command( $mysql_args, $assoc_args );
 
 		self::run(
 			sprintf(
@@ -2325,14 +2326,14 @@ class DB_Command extends WP_CLI_Command {
 	 * Get the statement that strips the SQL modes incompatible with WordPress
 	 * from the current session.
 	 *
-	 * The statement is run on the same connection as the import or query -- either
-	 * prepended to the executed batch, or via `--init-command` when importing from
-	 * STDIN (where there is no executed batch). Imports therefore behave like
-	 * WordPress Core (which disables these modes in `wpdb`), including when the
-	 * dump is streamed from STDIN. Unlike the previous implementation, no separate
-	 * connection is opened to first discover the current modes, so it works
-	 * regardless of the connection options in play (custom `--host`, `--defaults`,
-	 * SSL/TLS, sockets, ...).
+	 * The statement is applied on the same connection as the import or query via
+	 * the MySQL client's `--init-command`, so it runs on connect before any SQL is
+	 * read. Imports and queries therefore behave like WordPress Core (which
+	 * disables these modes in `wpdb`), including when a dump is streamed from
+	 * STDIN. Unlike the previous implementation, no separate connection is opened
+	 * to first discover the current modes, so it works regardless of the
+	 * connection options in play (custom `--host`, `--defaults`, SSL/TLS,
+	 * sockets, ...).
 	 *
 	 * Returns an empty string when the `--skip-sql-mode-compat` flag is set.
 	 *
@@ -2357,5 +2358,39 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return sprintf( "SET SESSION sql_mode = TRIM( BOTH ',' FROM %s )", $expression );
+	}
+
+	/**
+	 * Applies the WordPress SQL-mode compatibility statement to the MySQL client
+	 * arguments via `--init-command`, so it runs on connect before any SQL is read.
+	 *
+	 * If the caller already supplied their own `--init-command` (via the CLI or an
+	 * option file), the compatibility statement is composed with it as a single
+	 * multi-statement `--init-command` value -- the compatibility statement first,
+	 * the caller's command second -- rather than dropping either one. A caller that
+	 * re-sets `sql_mode` in their own command therefore still wins (last statement
+	 * takes effect), while the compatibility statement is guaranteed to run.
+	 *
+	 * Running both statements from a single `--init-command` value works across
+	 * every targeted client (mysql 5.6/5.7/8.0/8.4 and mariadb). The newer
+	 * `--init-command-add` option is only available on mysql 8.4+, so it is not
+	 * used here.
+	 *
+	 * Does nothing when compatibility is disabled via `--skip-sql-mode-compat`.
+	 *
+	 * @param array $mysql_args MySQL client arguments, passed by reference.
+	 * @param array $assoc_args The associative argument array passed to the command.
+	 */
+	protected function apply_sql_mode_compat_init_command( &$mysql_args, $assoc_args ) {
+		$sql_mode_compat = $this->get_sql_mode_compat_statement( $assoc_args );
+		if ( '' === $sql_mode_compat ) {
+			return;
+		}
+
+		if ( isset( $mysql_args['init-command'] ) && '' !== trim( (string) $mysql_args['init-command'] ) ) {
+			$mysql_args['init-command'] = $sql_mode_compat . '; ' . $mysql_args['init-command'];
+		} else {
+			$mysql_args['init-command'] = $sql_mode_compat;
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`wp db query`, `wp db import` and the internal `run_query()` all adapted the session SQL mode to match WordPress (stripping modes like `STRICT_TRANS_TABLES` and `NO_ZERO_DATE`, the way `wpdb` does). To build that adaptation, `get_sql_mode_query()` called `get_current_sql_modes()`, which **opened a second MySQL connection** to run `SELECT @@SESSION.sql_mode`.

That probe connection was built with `$args = []`, discarding the caller's connection options. So when you passed a custom `--host`, `--defaults`, SSL/TLS options or a socket, the probe connected to the *wrong* place (or failed outright) and aborted the whole command with `Failed to get current SQL modes`, before your actual query ever ran.

This is the root cause of #311 and its duplicates #237, #278, #288 and #218 (each one is a different connection option the probe failed to forward, patched one at a time).

## Approach

The probe is removed. Every path that needs WordPress SQL-mode compatibility now applies it through the MySQL client's **`--init-command`** on the *same* connection, so it runs right after connect and before any SQL is read — no second connection, so the connection options in play no longer matter.

1. **`wp db query`, `wp db import` and `run_query()` all adapt the session SQL mode via `--init-command`.** Behavior is unchanged from before for the default case: statements still run under WordPress-compatible modes, so DDL against WordPress's zero-date schema (`ALTER TABLE wp_blogs …`, `CREATE TABLE … AS SELECT` from a WordPress table, importing a headerless dump) keeps working on strict servers. This is **not** a breaking change.
2. **The STDIN import path (#171) is now covered too.** The old adaptation was prepended to the executed batch, which a STDIN stream never has; `--init-command` applies on connect regardless, so a dump streamed from STDIN gets the same treatment as a file import.
3. **New `--skip-sql-mode-compat` flag** on `wp db query` and `wp db import`, to run under the server's own SQL modes.

### Why compatibility matters

WordPress schema declares datetime columns as `DEFAULT '0000-00-00 00:00:00'`, so real dumps and tables carry zero-date values. On MySQL 5.7+/8.0 (default `sql_mode` includes `NO_ZERO_DATE`/`STRICT_TRANS_TABLES`), a raw statement against that schema without a relaxed session mode fails with `ERROR 1067 Invalid default value`. `mysqldump`/`wp db export` dumps carry their own `SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'` header, but headerless dumps (compact exports, hand-written SQL, some third-party tools) and ad-hoc DDL through `wp db query` still need the session mode relaxed — which is what `--init-command` now provides, by default.

### Implementation notes

- A shared helper, `apply_sql_mode_compat_init_command()`, is used by `query()`, `import()` and `run_query()`, so the logic lives in one place.
- The compat statement strips the incompatible modes from `@@SESSION.sql_mode` in a single expression. Each mode is comma-wrapped, e.g. `REPLACE(CONCAT(',', @@SESSION.sql_mode, ','), ',ANSI,', ',')`, so a mode name that is a substring of another (`ANSI` inside `ANSI_QUOTES`) is never corrupted.
- **Composition with a caller-supplied `--init-command`.** If the caller already set their own `--init-command` (via the CLI or an option file), the compat statement is composed with it into a **single multi-statement `--init-command`** — compat first, the caller's command second — rather than dropping either one. Compat first means it is always applied; a caller that re-sets `sql_mode` themselves still wins, since the last `SET` takes effect. This fixes the previous behavior, where a caller-provided `--init-command` on a STDIN import silently discarded the compat statement.
- **Why one `--init-command` and not `--init-command-add`.** MySQL 8.4 redefines `--init-command` as a single statement and adds `--init-command-add` for additional ones, but `--init-command-add` is rejected by mysql 5.6/5.7/8.0 and by the MariaDB client, so it is not portable. A single `--init-command` carrying two `;`-separated statements was verified to execute **both** on every CI-targeted client: mysql 5.6, 5.7, 8.0, 8.4 and mariadb 11.4. `--init-command` is likewise available across all of them; `get_mysql_binary_path()` selects the `mariadb` binary on MariaDB, which also supports it.

## Testing

New/updated Behat scenarios in `db-query.feature` and `db-import.feature`:
- `wp db query` adapts the SQL mode via `--init-command` by default, with no probe; `--skip-sql-mode-compat` disables it.
- Regression for #311: an inline query with connection options no longer triggers a failing probe.
- `wp db import` applies compat via `--init-command` by default; `--skip-sql-mode-compat` disables it.
- `wp db import` of a headerless zero-date dump succeeds, from both a file and STDIN (#171).
- `wp db import` keeps compat when the caller also passes `--init-command`.

The pre-existing `db.feature` / `db-tables.feature` scenarios that run DDL through `wp db query` (`CREATE TABLE … AS SELECT` from `wp_users`, `ALTER TABLE wp_blogs`) pass again on strict servers, which was the regression an earlier revision of this PR introduced.

## Known limitation

`$sql_incompatible_modes` does not include `NO_ZERO_IN_DATE` (it predates this PR). I kept the existing mode set to keep this change scoped to the probe fix. WordPress Core's list does include it, so adding it is a reasonable follow-up.

Fixes #311.
Fixes #171.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MySQL/MariaDB SQL-mode compatibility for `wp db import` and `wp db query`.
  * Added `--skip-sql-mode-compat` to disable automatic SQL-mode adjustments.
* **Bug Fixes**
  * Eliminated separate SQL-mode probing, making debug output more consistent.
  * Ensured inline queries with connection options (for example, `--defaults`) no longer fail.
  * Confirmed legacy “zero-date” datetime imports succeed with expected row counts.
  * SQL-mode adjustments now compose correctly with any caller-supplied `--init-command`.
* **Tests**
  * Expanded regression coverage for file/STDIN imports and query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->