### PR TITLE
Skip server certificate verification for MariaDB connections

### DIFF
--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -119,3 +119,21 @@ Feature: Query the database with WordPress' MySQL config
       """
       ANSI
       """
+
+  # Regression test for https://github.com/wp-cli/db-command/issues/309
+  # MariaDB 11.4+ verifies the server certificate by default and prints a warning to
+  # STDERR (or fails) against the auto-generated self-signed certificate, which broke
+  # the tests. `run()` now opts out via `--skip-ssl-verify-server-cert` on MariaDB, and
+  # both `ssl-verify-server-cert` and its `skip-` variant are allowed so the behaviour
+  # can be overridden. Assert the flag is forwarded to the MySQL client (visible in the
+  # debug output before the connection is attempted). SQLite does not use the MySQL
+  # client, hence the tag.
+  @require-mysql-or-mariadb
+  Scenario: Query forwards the ssl-verify-server-cert flags to the MySQL client
+    Given a WP install
+
+    When I try `wp db query "SELECT 1" --skip-ssl-verify-server-cert --debug`
+    Then STDERR should contain:
+      """
+      skip-ssl-verify-server-cert
+      """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1988,6 +1988,17 @@ class DB_Command extends WP_CLI_Command {
 			unset( $assoc_args['dbpass'], $assoc_args['password'] );
 		}
 
+		// MariaDB 11.4 enables TLS server certificate verification by default. WP-CLI
+		// connects the same way WordPress does, which does not verify the certificate,
+		// and against MariaDB's auto-generated self-signed certificate verification
+		// either just warns on STDERR that it disabled itself or fails outright. Opt out
+		// explicitly to keep the previous behaviour, unless the user asked to verify.
+		if ( 'mariadb' === Utils\get_db_type()
+			&& ! isset( $assoc_args['ssl-verify-server-cert'] )
+			&& ! isset( $assoc_args['skip-ssl-verify-server-cert'] ) ) {
+			$required['skip-ssl-verify-server-cert'] = true;
+		}
+
 		$final_args = array_merge( $required, $assoc_args );
 
 		// Filter out empty string values to avoid passing empty parameters to MySQL commands
@@ -2232,6 +2243,7 @@ class DB_Command extends WP_CLI_Command {
 			'skip-pager',
 			'skip-reconnect',
 			'skip-ssl',
+			'skip-ssl-verify-server-cert',
 			'socket',
 			'ssl',
 			'ssl-ca',
@@ -2243,6 +2255,7 @@ class DB_Command extends WP_CLI_Command {
 			'ssl-fips-mode',
 			'ssl-key',
 			'ssl-mode',
+			'ssl-verify-server-cert',
 			'syslog',
 			'table',
 			'tee',


### PR DESCRIPTION
## Summary

MariaDB 11.4 enables TLS server certificate verification by default. WP-CLI
connects the same way WordPress does, which does not verify the server
certificate. Against MariaDB's auto-generated self-signed certificate the client
either prints a warning to STDERR:

    WARNING: option --ssl-verify-server-cert is disabled, because of an insecure passwordless login.

or fails the connection outright. The warning fails the Behat tests on MariaDB
(#309) and is noise for anyone running `wp db` commands against MariaDB.

## Approach

`run()` now passes `--skip-ssl-verify-server-cert` on MariaDB, keeping the
pre-11.4 behaviour where the server certificate is not verified (the same as
WordPress itself). The warning already reports that MariaDB disabled
verification for these connections, so making the opt-out explicit does not
change the effective security posture, it just silences the warning.

This is an alternative to #310, which added `--ssl-verify-server-cert` (enabling
verification). Enabling it turns on certificate checks that fail against
self-signed or untrusted certificates, and on clients older than 11.4 where
verification was off by default, so it can break real connections rather than
just silencing the warning. Users who do want verification can still pass
`--ssl-verify-server-cert` themselves, since both that flag and its `skip-`
variant are now allowed as MySQL client options.

Addresses #309. The remaining MariaDB failure (`wp db repair --verbose`,
a pre-existing MySQL-vs-MariaDB verbose-output difference) is tracked in #335.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `wp db query` compatibility with MariaDB connections by handling SSL certificate verification consistently.
  * MariaDB connections now skip server certificate verification by default when no SSL verification option is specified.
  * Added support for explicitly enabling or skipping server certificate verification through command-line options.
* **Tests**
  * Added regression coverage confirming the SSL verification option is forwarded to the MySQL client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->