### PR TITLE
Fix `wp db repair --verbose` test for MariaDB

### DIFF
--- a/features/db.feature
+++ b/features/db.feature
@@ -181,14 +181,18 @@ Feature: Perform database operations
       """
     And STDOUT should be empty
 
-    # Verbose option prints to STDERR.
-    When I try `wp db repair --verbose`
+    # `--verbose` makes the check command print progress information. MySQL's
+    # mysqlcheck writes "# Connecting to ..." to STDERR at a single --verbose,
+    # while MariaDB's mariadb-check writes "Processing databases" to STDOUT and
+    # only prints connection information at a higher verbosity. Merge the streams
+    # and accept either client's marker.
+    When I try `wp db repair --verbose 2>&1`
     Then the return code should be 0
-    And STDERR should contain:
+    And STDOUT should match /(?:# Connecting to |Processing databases)/
+    And STDOUT should contain:
       """
-      Connecting
+      Success: Database repaired.
       """
-    And STDOUT should not be empty
 
   @skip-sqlite
   Scenario: db repair with --quiet flag should only show errors


### PR DESCRIPTION
## Summary

`features/db.feature`'s "DB Operations with passed-in options" scenario asserted
that `wp db repair --verbose` writes `Connecting` to STDERR. That only holds on
MySQL: its `mysqlcheck` writes `# Connecting to ...` to STDERR at a single
`--verbose`, but MariaDB's `mariadb-check` writes `Processing databases` to
STDOUT and only prints connection information at a higher verbosity level. So the
assertion passed on MySQL and failed on MariaDB.

## Approach

There is no single verbose-only string both clients emit at one `--verbose`, so
the step now merges the streams (`2>&1`) and matches either client's marker
(`# Connecting to ` or `Processing databases`), plus the `wp db repair` success
message so the scenario still proves the command ran.

This is the one remaining MariaDB failure after #334 (which silenced the
`--ssl-verify-server-cert` warnings). This PR is based on that branch so its CI
exercises both fixes together; it should be retargeted to the default branch once
#334 lands.

Fixes #335.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database repair verification across MySQL and MariaDB.
  * Confirmed successful repairs by validating the appropriate connection or processing message and the final success notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->