### PR TITLE
Modernize deprecated syntax in Behat tests

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -147,7 +147,7 @@ Feature: Import a WordPress database
       wp db import
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS}`
     Then STDOUT should not be empty
     And the wp-config.php file should exist
 


### PR DESCRIPTION
## What

Updates the Behat tests to use the current command syntax instead of forms deprecated by wp-cli/wp-cli#6356.

## Why

The framework now emits a deprecation warning to STDERR when it rewrites these legacy forms. This breaks `When I run` steps, which expect STDERR to remain empty.

## Tests

- `composer test`
