### PR TITLE
Bail early when check/dump commands are missing

### DIFF
--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -154,13 +154,13 @@ Feature: Check the database
     Given a WP install
 
     When I try `wp db check --defaults --debug`
-    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) %s#
+    Then STDERR should match #Debug \(db\): Running shell command: /([^/]+/)+(mysqlcheck|mariadb-check) %s#
 
     When I try `wp db check --debug`
-    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) --no-defaults %s#
+    Then STDERR should match #Debug \(db\): Running shell command: /([^/]+/)+(mysqlcheck|mariadb-check) --no-defaults %s#
 
     When I try `wp db check --no-defaults --debug`
-    Then STDERR should match #Debug \(db\): Running shell command: /usr/bin/env (mysqlcheck|mariadb-check) --no-defaults %s#
+    Then STDERR should match #Debug \(db\): Running shell command: /([^/]+/)+(mysqlcheck|mariadb-check) --no-defaults %s#
 
   @require-mysql-or-mariadb
   Scenario: Empty DB credentials should not cause empty parameter errors

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -140,13 +140,13 @@ Feature: Export a WordPress database
     Given a WP install
 
     When I try `wp db export --defaults --debug`
-    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump)#
+    Then STDERR should match #Debug \(db\): Running initial shell command: /([^/]+/)+(mysqldump|mariadb-dump)#
 
     When I try `wp db export --debug`
-    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump) --no-defaults#
+    Then STDERR should match #Debug \(db\): Running initial shell command: /([^/]+/)+(mysqldump|mariadb-dump) --no-defaults#
 
     When I try `wp db export --no-defaults --debug`
-    Then STDERR should match #Debug \(db\): Running initial shell command: /usr/bin/env (mysqldump|mariadb-dump) --no-defaults#
+    Then STDERR should match #Debug \(db\): Running initial shell command: /([^/]+/)+(mysqldump|mariadb-dump) --no-defaults#
 
   @skip-sqlite
   @skip-windows

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -286,9 +286,14 @@ class DB_Command extends WP_CLI_Command {
 			return;
 		}
 
+		$check_command = Utils\get_sql_check_command();
+		if ( '' === $check_command ) {
+			WP_CLI::error( 'The mysqlcheck or mariadb-check binary is not available.' );
+		}
+
 		$command = sprintf(
-			'/usr/bin/env %s%s %s',
-			Utils\get_sql_check_command(),
+			'%s%s %s',
+			$check_command,
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -347,9 +352,14 @@ class DB_Command extends WP_CLI_Command {
 			return;
 		}
 
+		$check_command = Utils\get_sql_check_command();
+		if ( '' === $check_command ) {
+			WP_CLI::error( 'The mysqlcheck or mariadb-check binary is not available.' );
+		}
+
 		$command = sprintf(
-			'/usr/bin/env %s%s %s',
-			Utils\get_sql_check_command(),
+			'%s%s %s',
+			$check_command,
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -408,9 +418,14 @@ class DB_Command extends WP_CLI_Command {
 			return;
 		}
 
+		$check_command = Utils\get_sql_check_command();
+		if ( '' === $check_command ) {
+			WP_CLI::error( 'The mysqlcheck or mariadb-check binary is not available.' );
+		}
+
 		$command = sprintf(
-			'/usr/bin/env %s%s %s',
-			Utils\get_sql_check_command(),
+			'%s%s %s',
+			$check_command,
 			$this->get_defaults_flag_string( $assoc_args ),
 			'%s'
 		);
@@ -756,7 +771,12 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['result-file'] = $result_file;
 		}
 
-		$mysqldump_binary = Utils\force_env_on_nix_systems( Utils\get_sql_dump_command() );
+		$dump_command = Utils\get_sql_dump_command();
+		if ( '' === $dump_command ) {
+			WP_CLI::error( 'The mysqldump or mariadb-dump binary is not available.' );
+		}
+
+		$mysqldump_binary = $dump_command;
 
 		$support_column_statistics = $this->command_supports_option( $mysqldump_binary, 'column-statistics' );
 


### PR DESCRIPTION
Bails early with an error in `db check`, `db optimize`, `db repair`, and `db export` when `get_sql_check_command()` or `get_sql_dump_command()` returns an empty string because the binaries are missing.

Follow-up to wp-cli/wp-cli#6363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database check, optimization, repair, and export commands by validating that the required database utilities are available before execution.
  * Added clearer errors when required database command-line tools cannot be found.
  * Updated debug output handling to accurately reflect the executable paths used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->