### PR TITLE
db import: Reject dot-commands in SQLite dump files

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -248,6 +248,22 @@ Feature: Import a WordPress database
       🍣
       """
 
+  @require-sqlite
+  Scenario: `wp db import` rejects dot-commands in SQLite dump files
+    Given a WP install
+    And a malicious_sqlite.sql file:
+      """
+      CREATE TABLE wp_cli_sqlite_meta (id int NOT NULL);
+      .shell touch side_effect_sqlite.txt
+      """
+
+    When I try `wp db import malicious_sqlite.sql`
+    Then STDERR should contain:
+      """
+      SQLite dot-commands are not allowed in import files.
+      """
+    And the side_effect_sqlite.txt file should not exist
+
   # SQLite does not use the MySQL client and has no concept of SQL modes.
   @require-mysql-or-mariadb
   Scenario: `wp db import` adapts the SQL mode via --init-command by default

--- a/src/DB_Command_SQLite.php
+++ b/src/DB_Command_SQLite.php
@@ -454,6 +454,10 @@ trait DB_Command_SQLite {
 			$contents = (string) file_get_contents( $file );
 		}
 
+		if ( preg_match( '/^\s*\.[a-zA-Z]+/m', $contents ) ) {
+			WP_CLI::error( 'SQLite dot-commands are not allowed in import files.' );
+		}
+
 		// Ignore errors about unique constraints and existing indexes.
 		$contents = str_replace( 'INSERT INTO', 'INSERT OR IGNORE INTO', $contents );
 		$contents = preg_replace( '/\bCREATE TABLE (?!IF NOT EXISTS\b)/i', 'CREATE TABLE IF NOT EXISTS ', $contents );


### PR DESCRIPTION
Applying some slight hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite imports now reject files containing unsupported dot-commands.
  * Clear command-line errors are shown, and rejected commands no longer create unintended files.
* **Tests**
  * Added regression coverage to verify dot-command rejection and prevent related side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->