### PR TITLE
Adapt SQLite support to sqlite-database-integration 3.0

### DIFF
--- a/features/db-columns.feature
+++ b/features/db-columns.feature
@@ -58,7 +58,8 @@ Feature: Display information about a given table.
     And I run `wp db query "CREATE TABLE not_wp ( date DATE NOT NULL, awesome_stuff TEXT, PRIMARY KEY (date) );;"`
 
     When I try `wp db columns not_wp`
+    # The `Extra` column is left out because `wp db columns` omits it on SQLite.
     Then STDOUT should be a table containing rows:
       | Field         | Type       | Null | Key | Default |
-      | date          | TEXT       | NO   | PRI | ''      |
-      | awesome_stuff | TEXT       | YES  |     |         |
+      | date          | date       | NO   | PRI |         |
+      | awesome_stuff | text       | YES  |     |         |

--- a/features/db-columns.feature
+++ b/features/db-columns.feature
@@ -41,7 +41,6 @@ Feature: Display information about a given table.
       Couldn't find any tables matching: wp_foobar
       """
 
-  @require-mysql-or-mariadb
   Scenario: Display information about a non default WordPress table
     Given a WP install
     And I run `wp db query "CREATE TABLE not_wp ( date DATE NOT NULL, awesome_stuff TEXT, PRIMARY KEY (date) );;"`
@@ -51,15 +50,3 @@ Feature: Display information about a given table.
       | Field         | Type       | Null | Key | Default | Extra |
       | date          | date       | NO   | PRI |         |       |
       | awesome_stuff | text       | YES  |     |         |       |
-
-  @require-sqlite
-  Scenario: Display information about a non default WordPress table
-    Given a WP install
-    And I run `wp db query "CREATE TABLE not_wp ( date DATE NOT NULL, awesome_stuff TEXT, PRIMARY KEY (date) );;"`
-
-    When I try `wp db columns not_wp`
-    # The `Extra` column is left out because `wp db columns` omits it on SQLite.
-    Then STDOUT should be a table containing rows:
-      | Field         | Type       | Null | Key | Default |
-      | date          | date       | NO   | PRI |         |
-      | awesome_stuff | text       | YES  |     |         |

--- a/features/db-tables.feature
+++ b/features/db-tables.feature
@@ -1,6 +1,5 @@
 Feature: List database tables
 
-  @require-mysql-or-mariadb
   Scenario: List database tables on a single WordPress install
     Given a WP install
 
@@ -36,40 +35,7 @@ Feature: List database tables
       wp_postmeta,wp_posts
       """
 
-  @require-sqlite
-  Scenario: List database tables on a single WordPress install
-    Given a WP install
-
-    When I run `wp db tables`
-    Then STDOUT should contain:
-      """
-      wp_users
-      wp_usermeta
-      wp_termmeta
-      wp_terms
-      wp_term_taxonomy
-      wp_term_relationships
-      wp_commentmeta
-      wp_comments
-      wp_links
-      wp_options
-      wp_postmeta
-      wp_posts
-      """
-
-    When I run `wp db tables --format=csv`
-    Then STDOUT should contain:
-      """
-      ,wp_commentmeta,wp_comments,
-      """
-
-    When I run `wp db tables 'wp_post*' --format=csv`
-    Then STDOUT should be:
-      """
-      wp_postmeta,wp_posts
-      """
-
-  @require-wp-3.9 @require-mysql-or-mariadb
+  @require-wp-3.9
   Scenario: List database tables on a multisite WordPress install
     Given a WP multisite install
 
@@ -100,84 +66,6 @@ Feature: List database tables
       wp_terms
       wp_usermeta
       wp_users
-      """
-
-    When I run `wp site create --slug=foo`
-    And I run `wp db tables --url=example.com/foo`
-    Then STDOUT should contain:
-      """
-      wp_users
-      """
-    And STDOUT should contain:
-      """
-      wp_usermeta
-      """
-    And STDOUT should contain:
-      """
-      wp_2_posts
-      """
-
-    When I run `wp db tables --url=example.com/foo --scope=global`
-    Then STDOUT should not contain:
-      """
-      wp_2_posts
-      """
-
-    When I run `wp db tables --all-tables-with-prefix`
-    Then STDOUT should contain:
-      """
-      wp_2_posts
-      """
-    And STDOUT should contain:
-      """
-      wp_posts
-      """
-
-    When I run `wp db tables --url=example.com/foo --all-tables-with-prefix`
-    Then STDOUT should contain:
-      """
-      wp_2_posts
-      """
-    And STDOUT should not contain:
-      """
-      wp_posts
-      """
-
-    When I run `wp db tables --url=example.com/foo --network`
-    Then STDOUT should contain:
-      """
-      wp_2_posts
-      """
-    And STDOUT should contain:
-      """
-      wp_posts
-      """
-
-  @require-sqlite
-  Scenario: List database tables on a multisite WordPress install
-    Given a WP multisite install
-
-    When I run `wp db tables`
-    Then STDOUT should contain:
-      """
-      wp_users
-      wp_usermeta
-      wp_termmeta
-      wp_terms
-      wp_term_taxonomy
-      wp_term_relationships
-      wp_commentmeta
-      wp_comments
-      wp_links
-      wp_options
-      wp_postmeta
-      wp_posts
-      wp_blogs
-      wp_blogmeta
-      wp_registration_log
-      wp_site
-      wp_sitemeta
-      wp_signups
       """
 
     When I run `wp site create --slug=foo`

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1942,10 +1942,6 @@ class DB_Command extends WP_CLI_Command {
 
 		$formatter_fields = [ 'Field', 'Type', 'Null', 'Key', 'Default', 'Extra' ];
 
-		if ( $this->is_sqlite() ) {
-			$formatter_fields = [ 'Field', 'Type', 'Null', 'Key', 'Default' ];
-		}
-
 		$formatter_args = [
 			'format' => $format,
 		];

--- a/src/DB_Command_SQLite.php
+++ b/src/DB_Command_SQLite.php
@@ -221,6 +221,19 @@ trait DB_Command_SQLite {
 			WP_CLI::error( 'SQLite database not available.' );
 		}
 
+		/*
+		 * Strip redundant trailing semicolons and whitespace.
+		 *
+		 * The MySQL client silently ignores the empty statements they produce,
+		 * whereas the SQLite drop-in parses them as a multi-query and bails out
+		 * with "Multi-query is not supported.". Trim them for parity.
+		 */
+		$query = rtrim( $query, "; \t\n\r\0\x0B" );
+
+		if ( '' === $query ) {
+			WP_CLI::error( 'No query specified.' );
+		}
+
 		$skip_column_names = Utils\get_flag_value( $assoc_args, 'skip-column-names', false );
 
 		try {


### PR DESCRIPTION
Every `SQLite` job in the matrix has been failing since sqlite-database-integration 3.0 replaced the old translation layer with the MySQL-on-SQLite driver. The MySQL/MariaDB jobs are unaffected. Example run: https://github.com/wp-cli/db-command/actions/runs/31762124942

Three driver behaviors changed. Each was verified by driving the 3.0 driver directly against an in-memory SQLite database rather than inferred from the CI output.

### `SHOW TABLES` is now sorted and honors `WHERE`

The translation ends in `ORDER BY table_name`, and the `WHERE ... IN (...)` clause that `Utils\wp_get_table_names()` builds is now applied. `wp db tables` therefore returns the same alphabetically sorted list on SQLite as it does on MySQL.

The `@require-sqlite` variants of the two `db tables` scenarios differed from their MySQL counterparts *only* in that ordering, so this drops the duplicates and lets the original scenarios cover both database types.

Note that the `array_intersect()` SQLite workaround in wp-cli's `wp_get_table_names()` is now a no-op, but it still does real work against the 2.x drop-in, so it is best left alone until 3.0 is a hard requirement. No framework change is needed here.

### `SHOW COLUMNS` reports MySQL types and the `Extra` field

Types come back as `date`/`text` rather than the underlying SQLite storage types, and an absent default is `NULL` rather than a quoted empty string. This was verified to hold under the default SQL mode, wpdb's filtered mode, and an empty mode, so it does not depend on `sql_mode`.

The driver also returns the `Extra` field now. `columns()` dropped it on SQLite because the old drop-in did not provide it; that workaround now hides information that is available, notably `auto_increment`, so it is removed. With `Extra` restored the SQLite `db columns` scenario expects exactly what the MySQL one does, so that duplicate goes too.

### Multi-queries are rejected

`wp db query "CREATE TABLE ... );;"` fails with `Multi-query is not supported.` — the stray second semicolon parses as an empty second statement. The MySQL client silently ignores it, which is why that line sat unnoticed in `db-columns.feature`.

Rather than edit the test, this trims redundant trailing semicolons in the SQLite query path so `wp db query` behaves the same on both backends. The `;;` stays in the feature file as regression coverage.

### Not addressed here

`wp db export` includes the driver's internal `_wp_sqlite_*` tables in the dump. That looks like something to strip, but excluding them is worse: a round-trip through a stripped dump reconstructs the schema lossily, turning `bigint(20) unsigned` into `int`, `datetime` into `varchar(65535)`, `longtext` into `text`, and `NOT NULL` columns into nullable ones. On tables with an auto-increment column, every column additionally comes back marked `auto_increment` and all defaults are lost, which looks like a bug worth reporting upstream.

Since `wp db export` on SQLite emits a `sqlite3 .dump` whose only real consumer is `wp db import` into another SQLite install, keeping the information schema is the correct behavior. The existing `_mysql_data_types_cache` exclusion is dead code under 3.0 and harmless.

One inconsistency does remain: `wp db export --tables=...` builds its exclusion list as "everything not requested", which sweeps the internal tables out, so targeted exports are lossy while full exports are not. Happy to address that separately if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXbmdB7hvQ2jwEe64h6s5K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database column listings now consistently include the `Extra` field for SQLite output.
  * SQLite queries now handle trailing semicolons and whitespace correctly.
  * Empty SQLite queries now return a clear “No query specified.” error.

* **Tests**
  * Updated database scenario coverage to reflect consistent behavior across supported database types and WordPress versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->