### PR TITLE
db import: Improve SQLite dot-command detection regex

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -256,6 +256,16 @@ Feature: Import a WordPress database
       CREATE TABLE wp_cli_sqlite_meta (id int NOT NULL);
       .shell touch side_effect_sqlite.txt
       """
+    And a malicious_sqlite_space.sql file:
+      """
+      CREATE TABLE wp_cli_sqlite_meta (id int NOT NULL);
+      . shell touch side_effect_sqlite_space.txt
+      """
+    And a malicious_sqlite_quotes.sql file:
+      """
+      CREATE TABLE wp_cli_sqlite_meta (id int NOT NULL);
+      ."shell" touch side_effect_sqlite_quotes.txt
+      """
 
     When I try `wp db import malicious_sqlite.sql`
     Then STDERR should contain:
@@ -263,6 +273,20 @@ Feature: Import a WordPress database
       SQLite dot-commands are not allowed in import files.
       """
     And the side_effect_sqlite.txt file should not exist
+
+    When I try `wp db import malicious_sqlite_space.sql`
+    Then STDERR should contain:
+      """
+      SQLite dot-commands are not allowed in import files.
+      """
+    And the side_effect_sqlite_space.txt file should not exist
+
+    When I try `wp db import malicious_sqlite_quotes.sql`
+    Then STDERR should contain:
+      """
+      SQLite dot-commands are not allowed in import files.
+      """
+    And the side_effect_sqlite_quotes.txt file should not exist
 
   # SQLite does not use the MySQL client and has no concept of SQL modes.
   @require-mysql-or-mariadb

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -288,6 +288,29 @@ Feature: Import a WordPress database
       """
     And the side_effect_sqlite_quotes.txt file should not exist
 
+  @require-sqlite
+  Scenario: `wp db import` allows multiline SQL containing numeric literals starting with a dot
+    Given a WP install
+    And a numeric_literal.sql file:
+      """
+      CREATE TABLE wp_cli_prices (value REAL);
+      INSERT INTO wp_cli_prices (value) VALUES (
+      .5
+      );
+      """
+
+    When I run `wp db import numeric_literal.sql`
+    Then STDOUT should contain:
+      """
+      Success: Imported from 'numeric_literal.sql'.
+      """
+
+    When I run `wp db query 'SELECT value FROM wp_cli_prices;' --skip-column-names`
+    Then STDOUT should be:
+      """
+      0.5
+      """
+
   # SQLite does not use the MySQL client and has no concept of SQL modes.
   @require-mysql-or-mariadb
   Scenario: `wp db import` adapts the SQL mode via --init-command by default

--- a/src/DB_Command_SQLite.php
+++ b/src/DB_Command_SQLite.php
@@ -467,7 +467,7 @@ trait DB_Command_SQLite {
 			$contents = (string) file_get_contents( $file );
 		}
 
-		if ( preg_match( '/^[ \t]*\./m', $contents ) ) {
+		if ( preg_match( '/^[ \t]*\.(?![0-9])/m', $contents ) ) {
 			WP_CLI::error( 'SQLite dot-commands are not allowed in import files.' );
 		}
 

--- a/src/DB_Command_SQLite.php
+++ b/src/DB_Command_SQLite.php
@@ -467,7 +467,7 @@ trait DB_Command_SQLite {
 			$contents = (string) file_get_contents( $file );
 		}
 
-		if ( preg_match( '/^\s*\.[a-zA-Z]+/m', $contents ) ) {
+		if ( preg_match( '/^[ \t]*\./m', $contents ) ) {
 			WP_CLI::error( 'SQLite dot-commands are not allowed in import files.' );
 		}
 


### PR DESCRIPTION
Improve the SQLite dot-command matching regex in `wp db import` to catch variations with whitespace or quotes, and expand acceptance test coverage.

Follow-up to #340.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SQLite imports now reject dot-commands with leading spaces or quoted command names.
  - Blocked imports no longer create unintended side-effect files.
  - Valid SQLite numeric literals beginning with a dot, such as `.5`, can now be imported successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->